### PR TITLE
Task-58153: Update agenda connectors addon develop version

### DIFF
--- a/agenda-connectors-api/pom.xml
+++ b/agenda-connectors-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.agenda-connectors</groupId>
     <artifactId>agenda-connectors-parent</artifactId>
-    <version>1.0.x-SNAPSHOT</version>
+    <version>1.1.x-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-connectors-api</artifactId>
   <name>eXo Agenda Connectors - API</name>

--- a/agenda-connectors-packaging/pom.xml
+++ b/agenda-connectors-packaging/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.addons.agenda-connectors</groupId>
     <artifactId>agenda-connectors-parent</artifactId>
-    <version>1.0.x-SNAPSHOT</version>
+    <version>1.1.x-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-connectors-packaging</artifactId>
   <packaging>pom</packaging>

--- a/agenda-connectors-services/pom.xml
+++ b/agenda-connectors-services/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.agenda-connectors</groupId>
     <artifactId>agenda-connectors-parent</artifactId>
-    <version>1.0.x-SNAPSHOT</version>
+    <version>1.1.x-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-connectors-services</artifactId>
   <name>eXo Agenda Connectors - Services</name>

--- a/agenda-connectors-webapp/pom.xml
+++ b/agenda-connectors-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.exoplatform.addons.agenda-connectors</groupId>
     <artifactId>agenda-connectors-parent</artifactId>
-    <version>1.0.x-SNAPSHOT</version>
+    <version>1.1.x-SNAPSHOT</version>
   </parent>
   <artifactId>agenda-connectors-webapp</artifactId>
   <packaging>war</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.exoplatform.addons.agenda-connectors</groupId>
   <artifactId>agenda-connectors-parent</artifactId>
-  <version>1.0.x-SNAPSHOT</version>
+  <version>1.1.x-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Agenda Connectors - Parent POM</name>
   <modules>


### PR DESCRIPTION
Since this addon will be deployed with eXo 6.3.1 version, a new branch stable/1.0.x with 1.0.x-SNAPSHOT version should be created thus the develop version should be updated to 1.1.x-SNAPSHOT