### PR TITLE
TASK-58004_58005: Display Exchange agenda connector in "Connect You Personal Agenda" drawer from event display, event creation and edit

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/exchange-connector/agendaExchangeConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/exchange-connector/agendaExchangeConnector.js
@@ -21,7 +21,7 @@ export default {
   isOauth: false,
   canConnect: true,
   canPush: false,
-  initialized: false,
+  initialized: true,
   isSignedIn: false,
   pushing: false,
 };


### PR DESCRIPTION
After this change we display the exchange agenda connector in "Connect You Personal Agenda" drawer from event display, event creation and edit. The problem was that connectors are filtered by the initialized attribute true, so it is fixed by setting the initialized attribute value of the exchange agenda connector to true.