### PR TITLE
Task-58722: Retrieve events data from exchange server

### DIFF
--- a/agenda-connectors-api/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorService.java
+++ b/agenda-connectors-api/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorService.java
@@ -29,8 +29,9 @@ public interface ExchangeConnectorService {
    *
    * @param userIdentityId User identity creating the exchange user setting
    * @param exchangeUserSetting {@link ExchangeUserSetting} object to create
+   * @throws IllegalAccessException when the user is not authorized to create exchange setting
    */
-  void createExchangeSetting(ExchangeUserSetting exchangeUserSetting, long userIdentityId);
+  void createExchangeSetting(ExchangeUserSetting exchangeUserSetting, long userIdentityId) throws IllegalAccessException;
 
   /**
    * Retrieves exchange user setting by its technical user identity identifier.
@@ -48,18 +49,14 @@ public interface ExchangeConnectorService {
   void deleteExchangeSetting(long userIdentityId);
 
   /**
-   * Retrieves list of remote events from Exchange connector.
+   * Retrieves remote user exchange events.
    *
    * @param userTimeZone User time zone
    * @return {@link List} of {@link EventEntity}
+   * @throws IllegalAccessException when the user is not authorized to get remote user exchange events
    */
-  List<EventEntity> getEvents(String start, String end, ZoneId userTimeZone);
-
-  /** 
-   * Connects to exchange server by exchange user setting.
-   *
-   * @param exchangeUserSetting {@link ExchangeUserSetting} object to connect to exchange server
-   * @throws IllegalAccessException when the connection to exchange server is not established
-   */
-  void connectExchangeSetting(ExchangeUserSetting exchangeUserSetting) throws IllegalAccessException;
+  List<EventEntity> getExchangeEvents(long userIdentityId,
+                                      String start,
+                                      String end,
+                                      ZoneId userTimeZone) throws IllegalAccessException;
 }

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/rest/ExchangeConnectorRest.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/rest/ExchangeConnectorRest.java
@@ -16,14 +16,23 @@
  */
 package org.exoplatform.agendaconnector.rest;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+
 import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang3.StringUtils;
+
 import org.exoplatform.agenda.rest.model.EventEntity;
 import org.exoplatform.agendaconnector.model.ExchangeUserSetting;
 import org.exoplatform.agendaconnector.service.ExchangeConnectorService;
@@ -36,10 +45,8 @@ import org.exoplatform.social.core.manager.IdentityManager;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.util.*;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/v1/exchange")
 public class ExchangeConnectorRest implements ResourceContainer {
@@ -59,16 +66,21 @@ public class ExchangeConnectorRest implements ResourceContainer {
   @Consumes(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @ApiOperation(value = "Create exchange user setting", httpMethod = "POST", response = Response.class, consumes = "application/json")
-  public Response createExchangeSetting(@ApiParam(value = "Exchange user setting object to create", required = true)
-  ExchangeUserSetting exchangeUserSetting) {
+  @ApiResponses(value = { @ApiResponse(code = HTTPStatus.OK, message = "Request fulfilled"),
+      @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
+      @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "Unauthorized operation"),
+      @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error") })
+  public Response createExchangeSetting(@ApiParam(value = "Exchange user setting object to create", required = true) ExchangeUserSetting exchangeUserSetting) {
     if (exchangeUserSetting == null) {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
     long identityId = ExchangeConnectorUtils.getCurrentUserIdentityId(identityManager);
     try {
-      exchangeConnectorService.connectExchangeSetting(exchangeUserSetting);
       exchangeConnectorService.createExchangeSetting(exchangeUserSetting, identityId);
       return Response.ok().build();
+    } catch (IllegalAccessException e) {
+      LOG.warn("User '{}' is not autorized to connect to exchange server", identityId, e);
+      return Response.status(Response.Status.UNAUTHORIZED).entity(e.getMessage()).build();
     } catch (Exception e) {
       LOG.error("Error when creating exchange user setting ", e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
@@ -79,12 +91,14 @@ public class ExchangeConnectorRest implements ResourceContainer {
   @RolesAllowed("users")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get exchange user setting", httpMethod = "GET", response = Response.class, produces = "application/json")
+  @ApiResponses(value = { @ApiResponse(code = HTTPStatus.OK, message = "Request fulfilled"),
+      @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error") })
   public Response getExchangeSetting() {
     long identityId = ExchangeConnectorUtils.getCurrentUserIdentityId(identityManager);
     try {
       return Response.ok(exchangeConnectorService. getExchangeSetting(identityId)).build();
     } catch (Exception e) {
-      LOG.warn("Error retrieving exchange user settings for user with id '{}'", identityId, e);
+      LOG.error("Error when retrieving exchange user settings for user with id '{}'", identityId, e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
     }
   }
@@ -92,13 +106,15 @@ public class ExchangeConnectorRest implements ResourceContainer {
   @DELETE
   @RolesAllowed("users")
   @ApiOperation(value = "Delete exchange user setting", httpMethod = "DELETE", response = Response.class)
+  @ApiResponses(value = { @ApiResponse(code = HTTPStatus.OK, message = "Request fulfilled"),
+      @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error") })
   public Response deleteExchangeSetting() {
     long identityId = ExchangeConnectorUtils.getCurrentUserIdentityId(identityManager);
     try {
       exchangeConnectorService.deleteExchangeSetting(identityId);
       return Response.ok().build();
     } catch (Exception e) {
-      LOG.error("Error when deleting exchange user setting ", e);
+      LOG.error("Error when deleting exchange user setting for user with id '{}'", identityId, e);
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
     }
   }
@@ -110,7 +126,8 @@ public class ExchangeConnectorRest implements ResourceContainer {
   @ApiOperation(value = "Retrieves the remote events list of Exchange Connector", httpMethod = "GET", response = Response.class, produces = "application/json")
   @ApiResponses(value = { @ApiResponse(code = HTTPStatus.OK, message = "Request fulfilled"),
       @ApiResponse(code = HTTPStatus.BAD_REQUEST, message = "Invalid query input"),
-      @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error"), })
+      @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "Unauthorized operation"),
+      @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error") })
   public Response getEvents(
                             @ApiParam(value = "Start datetime using RFC-3339 representation", required = true)
                             @QueryParam("start")
@@ -122,16 +139,26 @@ public class ExchangeConnectorRest implements ResourceContainer {
                             @QueryParam("timeZoneId")
                             String timeZoneId) {
 
+    long identityId = ExchangeConnectorUtils.getCurrentUserIdentityId(identityManager);
     if (StringUtils.isBlank(start)) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Start datetime is mandatory").build();
+    }
+    if (StringUtils.isBlank(end)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("End datetime is mandatory").build();
     }
     if (StringUtils.isBlank(timeZoneId)) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Time zone is mandatory").build();
     }
     ZoneId userTimeZone = StringUtils.isBlank(timeZoneId) ? ZoneOffset.UTC : ZoneId.of(timeZoneId);
-    List<EventEntity> events = exchangeConnectorService.getEvents(start, end, userTimeZone);
-
-    return Response.ok(events).build();
+    try {
+      List<EventEntity> events = exchangeConnectorService.getExchangeEvents(identityId, start, end, userTimeZone);
+      return Response.ok(events).build();
+    } catch (IllegalAccessException e) {
+      LOG.warn("User '{}' is not autorized to connect to exchange server or get exchange event informations", identityId, e);
+      return Response.status(Response.Status.UNAUTHORIZED).entity(e.getMessage()).build();
+    } catch (Exception e) {
+      LOG.error("Error when retrieving user exchange events ", e);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
   }
-
 }

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
@@ -129,7 +129,7 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
     String exchangeDomain = exchangeUserSetting.getDomainName();
     String exchangeUsername = exchangeUserSetting.getUsername();
     String exchangePassword = exchangeUserSetting.getPassword();
-    String exchangeServerURL = ExchangeConnectorUtils.EXCHANGE_SERVER_URL_PROPERTY;
+    String exchangeServerURL = System.getProperty(ExchangeConnectorUtils.EXCHANGE_SERVER_URL_PROPERTY);
     ExchangeCredentials credentials = null;
     if (exchangeDomain != null) {
       credentials = new WebCredentials(exchangeUsername, exchangePassword, exchangeDomain);

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
@@ -18,17 +18,32 @@ package org.exoplatform.agendaconnector.service;
 
 import java.net.URI;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.exoplatform.agenda.rest.model.EventEntity;
+import org.exoplatform.agenda.util.AgendaDateUtils;
 import org.exoplatform.agendaconnector.model.ExchangeUserSetting;
 import org.exoplatform.agendaconnector.storage.ExchangeConnectorStorage;
 import org.exoplatform.agendaconnector.utils.ExchangeConnectorUtils;
 
 import microsoft.exchange.webservices.data.core.ExchangeService;
 import microsoft.exchange.webservices.data.core.enumeration.misc.ExchangeVersion;
+import microsoft.exchange.webservices.data.core.enumeration.property.WellKnownFolderName;
+import microsoft.exchange.webservices.data.core.enumeration.search.LogicalOperator;
+import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
+import microsoft.exchange.webservices.data.core.service.item.Item;
+import microsoft.exchange.webservices.data.core.service.schema.AppointmentSchema;
 import microsoft.exchange.webservices.data.credential.ExchangeCredentials;
 import microsoft.exchange.webservices.data.credential.WebCredentials;
+import microsoft.exchange.webservices.data.property.definition.PropertyDefinition;
+import microsoft.exchange.webservices.data.search.FindItemsResults;
+import microsoft.exchange.webservices.data.search.ItemView;
+import microsoft.exchange.webservices.data.search.filter.SearchFilter;
 
 
 public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
@@ -40,14 +55,13 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
   }
 
   @Override
-  public void createExchangeSetting(ExchangeUserSetting exchangeUserSetting, long userIdentityId) {
-    if (userIdentityId <= 0) {
-      throw new IllegalArgumentException("User identity id is mandatory");
+  public void createExchangeSetting(ExchangeUserSetting exchangeUserSetting, long userIdentityId) throws IllegalAccessException {
+    try (ExchangeService exchangeService = new ExchangeService(ExchangeVersion.Exchange2010_SP2)) {
+      connectExchangeServer(exchangeService, exchangeUserSetting);
+      exchangeConnectorStorage.createExchangeSetting(exchangeUserSetting, userIdentityId);
+    } catch (Exception e) {
+      throw new IllegalAccessException("User " + userIdentityId + " is not allowed to connect to exchange server");
     }
-    if (exchangeUserSetting == null) {
-      throw new IllegalArgumentException("Exchange user setting is empty");
-    }
-    exchangeConnectorStorage.createExchangeSetting(exchangeUserSetting, userIdentityId);
   }
 
   @Override
@@ -61,29 +75,70 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
   }  
   
   @Override
-  public void connectExchangeSetting(ExchangeUserSetting exchangeUserSetting) throws IllegalAccessException {
+  public List<EventEntity> getExchangeEvents(long userIdentityId,
+                                     String start,
+                                     String end,
+                                     ZoneId userTimeZone) throws IllegalAccessException {
+    ExchangeUserSetting exchangeUserSetting = getExchangeSetting(userIdentityId);
     try (ExchangeService exchangeService = new ExchangeService(ExchangeVersion.Exchange2010_SP2)) {
-      exchangeService.setTimeout(300000);
-      String exchangeDomain = exchangeUserSetting.getDomainName();
-      String exchangeUsername = exchangeUserSetting.getUsername();
-      String exchangePassword = exchangeUserSetting.getPassword();
-      String exchangeServerURL = System.getProperty("exo.exchange.server.url");
-      ExchangeCredentials credentials = null;
-      if (exchangeDomain != null) {
-        credentials = new WebCredentials(exchangeUsername, exchangePassword, exchangeDomain);
-      } else {
-        credentials = new WebCredentials(exchangeUsername, exchangePassword);
+      connectExchangeServer(exchangeService, exchangeUserSetting);
+      ItemView view = new ItemView(100);
+
+      ZonedDateTime startZonedDateTime = AgendaDateUtils.parseAllDayDateToZonedDateTime(start);
+      SearchFilter exchangeStartSearchFilter = new SearchFilter.IsGreaterThanOrEqualTo(AppointmentSchema.Start,
+                                                                        AgendaDateUtils.toDate(startZonedDateTime));
+      ZonedDateTime endZonedDatetime = AgendaDateUtils.parseAllDayDateToZonedDateTime(end).plusDays(1);//We have added on day in order to get events of the end date day
+      SearchFilter exchangeEndSearchFilter = new SearchFilter.IsLessThanOrEqualTo(AppointmentSchema.End, AgendaDateUtils.toDate(endZonedDatetime));
+      
+      SearchFilter exchangeEventsSearchFilter = new SearchFilter.SearchFilterCollection(LogicalOperator.And, exchangeStartSearchFilter, exchangeEndSearchFilter);
+      FindItemsResults<Item> exchangeEventsItems = exchangeService.findItems(WellKnownFolderName.Calendar, exchangeEventsSearchFilter, view);
+      List<EventEntity> exchangeEvents = new ArrayList<>();
+      for (Item exchangeEventItem : exchangeEventsItems) {
+        EventEntity exchangeEvent = new EventEntity();
+        exchangeEvent.setSummary(exchangeEventItem.getSubject());
+        Map<PropertyDefinition, Object> exchangeEventItemProperties = exchangeEventItem.getPropertyBag().getProperties();
+
+        Date exchangeEventStartDate = (Date) Objects.requireNonNull(exchangeEventItemProperties.entrySet().stream()
+                                                               .filter(exchangeEventItemProperty -> exchangeEventItemProperty.getKey().getUri().equals(ExchangeConnectorUtils.EXCHANGE_APPOINTMENT_SCHEMA_START))
+                                                               .findFirst()
+                                                               .orElse(null))
+                                       .getValue();
+        ZonedDateTime exchangeEventStartDateTime = AgendaDateUtils.fromDate(exchangeEventStartDate).withZoneSameInstant(userTimeZone);
+        exchangeEvent.setStart(AgendaDateUtils.toRFC3339Date(exchangeEventStartDateTime));
+
+        Date exchangeEventEndDate = (Date) Objects.requireNonNull(exchangeEventItemProperties.entrySet().stream()
+                                                             .filter(exchangeEventItemProperty -> exchangeEventItemProperty.getKey().getUri().equals(ExchangeConnectorUtils.EXCHANGE_APPOINTMENT_SCHEMA_END))
+                                                             .findFirst()
+                                                             .orElse(null))
+                                     .getValue();
+        ZonedDateTime exchangeEventEndDateTime = AgendaDateUtils.fromDate(exchangeEventEndDate).withZoneSameInstant(userTimeZone);
+        exchangeEvent.setEnd(AgendaDateUtils.toRFC3339Date(exchangeEventEndDateTime));
+        exchangeEvents.add(exchangeEvent);
       }
-      exchangeService.setCredentials(credentials);
-      exchangeService.setUrl(new URI(exchangeServerURL + ExchangeConnectorUtils.EWS_URL));
-      exchangeService.getInboxRules();
+      return exchangeEvents;
+    } catch (ServiceLocalException e) {
+      throw new IllegalAccessException("User " + userIdentityId + " is not allowed to get exchange event informations");
     } catch (Exception e) {
-      throw new IllegalAccessException("Can not connect to exchange server");
+      throw new IllegalAccessException("User " + userIdentityId + " is not allowed to connect to exchange server");
     }
   }
-
-  @Override
-   public List<EventEntity> getEvents(String start, String end, ZoneId userTimeZone) {
-    return ExchangeConnectorStorage.getEvents(start, end, userTimeZone);
+    
+  private ExchangeService connectExchangeServer(ExchangeService exchangeService,
+                                                 ExchangeUserSetting exchangeUserSetting) throws Exception {
+    exchangeService.setTimeout(300000);
+    String exchangeDomain = exchangeUserSetting.getDomainName();
+    String exchangeUsername = exchangeUserSetting.getUsername();
+    String exchangePassword = exchangeUserSetting.getPassword();
+    String exchangeServerURL = ExchangeConnectorUtils.EXCHANGE_SERVER_URL_PROPERTY;
+    ExchangeCredentials credentials = null;
+    if (exchangeDomain != null) {
+      credentials = new WebCredentials(exchangeUsername, exchangePassword, exchangeDomain);
+    } else {
+      credentials = new WebCredentials(exchangeUsername, exchangePassword);
+    }
+    exchangeService.setCredentials(credentials);
+    exchangeService.setUrl(new URI(exchangeServerURL + ExchangeConnectorUtils.EWS_URL));
+    exchangeService.getInboxRules();
+    return exchangeService;
   }
 }

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/storage/ExchangeConnectorStorage.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/storage/ExchangeConnectorStorage.java
@@ -16,16 +16,11 @@
  */
 package org.exoplatform.agendaconnector.storage;
 
-import org.exoplatform.agenda.rest.model.EventEntity;
 import org.exoplatform.agendaconnector.model.ExchangeUserSetting;
 import org.exoplatform.agendaconnector.utils.ExchangeConnectorUtils;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Context;
-import org.exoplatform.agenda.util.AgendaDateUtils;
-import java.time.*;
-import java.util.ArrayList;
-import java.util.List;
 
 public class ExchangeConnectorStorage {
 
@@ -92,56 +87,4 @@ public class ExchangeConnectorStorage {
                                ExchangeConnectorUtils.EXCHANGE_PASSWORD_KEY);
   }
 
-  public static List<EventEntity> getEvents(String start, String end,ZoneId userTimeZone){
-
-    ZonedDateTime startDate1 = ZonedDateTime.of(LocalDate.now(), LocalTime.of(10, 0), userTimeZone).withZoneSameInstant(ZoneId.systemDefault());
-    ZonedDateTime startDate2 = startDate1.plusDays(1);
-    ZonedDateTime startDate3 = startDate2.plusDays(7);
-    ZonedDateTime startDate4 = startDate3.plusDays(1);
-
-
-
-    String startDateEvent1 = AgendaDateUtils.toRFC3339Date(startDate1);
-    String startDateEvent2 = AgendaDateUtils.toRFC3339Date(startDate2);
-    String startDateEvent3 = AgendaDateUtils.toRFC3339Date(startDate3);
-    String startDateEvent4 = AgendaDateUtils.toRFC3339Date(startDate4);
-
-    String endDateEvent1 = AgendaDateUtils.toRFC3339Date(startDate1.plusHours(1));
-    String endDateEvent2 = AgendaDateUtils.toRFC3339Date(startDate2.plusHours(1));
-    String endDateEvent3 = AgendaDateUtils.toRFC3339Date(startDate3.plusHours(1));
-    String endDateEvent4 = AgendaDateUtils.toRFC3339Date(startDate4.plusHours(1));
-
-    List<EventEntity> events = new ArrayList<>();
-    EventEntity event1 = new EventEntity();
-
-    event1.setId(10);
-    event1.setSummary("event1");
-    event1.setStart(startDateEvent1);
-    event1.setEnd(endDateEvent1);
-
-    EventEntity event2 = new EventEntity();
-    event2.setId(11);
-    event2.setSummary("event2");
-    event2.setStart(startDateEvent2);
-    event2.setEnd(endDateEvent2);
-
-    EventEntity event3 = new EventEntity();
-    event3.setId(12);
-    event3.setSummary("event3");
-    event3.setStart(startDateEvent3);
-    event3.setEnd(endDateEvent3);
-
-    EventEntity event4 = new EventEntity();
-    event4.setId(13);
-    event4.setSummary("event4");
-    event4.setStart(startDateEvent4);
-    event4.setEnd(endDateEvent4);
-
-    events.add(event1);
-    events.add(event2);
-    events.add(event3);
-    events.add(event4);
-
-    return events;
-  }
 }

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/utils/ExchangeConnectorUtils.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/utils/ExchangeConnectorUtils.java
@@ -39,8 +39,14 @@ public class ExchangeConnectorUtils {
 
   public static final String EXCHANGE_PASSWORD_KEY            = "ExchangePassword";
   
+  public static final String EXCHANGE_SERVER_URL_PROPERTY = "exo.exchange.server.url";
+  
   public static final String EWS_URL = "/EWS/Exchange.asmx";
-
+  
+  public static final String EXCHANGE_APPOINTMENT_SCHEMA_START = "calendar:Start";
+  
+  public static final String EXCHANGE_APPOINTMENT_SCHEMA_END = "calendar:End";
+  
   private ExchangeConnectorUtils() {
   }
 


### PR DESCRIPTION
Prior to this change, fake events are retrieved when the user is connected to exchange. After this change, real exchange events are retrieved when we schedule event or create event with alternative dates, edit event or display event detail.