### PR TITLE
feat: Replace deprecated gapi oauth module by gsi in google connector- EXO-59880 

### DIFF
--- a/agenda-connectors-webapp/.eslintrc.json
+++ b/agenda-connectors-webapp/.eslintrc.json
@@ -3,7 +3,8 @@
     "eslint-config-meedsio"
   ],
   "globals": {
-    "gapi": true
+    "gapi": true,
+    "google": true
   },
   "rules": {
     "vue/no-mutating-props": "warn",

--- a/agenda-connectors-webapp/package.json
+++ b/agenda-connectors-webapp/package.json
@@ -25,6 +25,7 @@
     "vue-template-compiler": "^2.6.14",
     "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
-    "webpack-merge": "^5.8.0"
+    "webpack-merge": "^5.8.0",
+    "jwt-decode": "^3.1.2"
   }
 }

--- a/agenda-connectors-webapp/src/main/webapp/WEB-INF/conf/agenda-connectors/agenda-connectors.xml
+++ b/agenda-connectors-webapp/src/main/webapp/WEB-INF/conf/agenda-connectors/agenda-connectors.xml
@@ -41,6 +41,10 @@
           <value>${exo.agenda.google.connector.key:}</value>
         </value-param>
         <value-param>
+          <name>connectorSecretKey</name>
+          <value>${exo.agenda.google.connector.secret:}</value>
+        </value-param>
+        <value-param>
           <name>connectorOauth</name>
           <value>true</value>
         </value-param>

--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
@@ -14,12 +14,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import jwt_decode from 'jwt-decode';
+
 export default {
   name: 'agenda.googleCalendar',
   description: 'agenda.googleCalendar.description',
   avatar: '/agenda-connectors/skin/images/Google.png',
   isOauth: true,
+  mandatorySecretKey: true,
   CLIENT_ID: null,
+  SECRET_KEY: null,
   DISCOVERY_DOCS: ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'],
   SCOPE_WRITE: 'https://www.googleapis.com/auth/calendar.events',
   canConnect: true,
@@ -28,12 +32,12 @@ export default {
   isSignedIn: false,
   pushing: false,
   rank: 10,
-  init(connectionStatusChangedCallback, loadingCallback, apiKey) {
-    if (!apiKey) {
-      throw new Error('Google connector can\'t be enabled with empty Client API Key.');
+  init(connectionStatusChangedCallback, loadingCallback, apiKey, secretKey) {
+    if (!apiKey || !secretKey) {
+      throw new Error('Google connector can\'t be enabled with empty Client API Key or empty Client Secret Key.');
     }
     this.CLIENT_ID = apiKey;
-
+    this.SECRET_KEY = secretKey;
     // Already initialized
     if (this.initialized) {
       return;
@@ -44,71 +48,143 @@ export default {
 
     initGoogleConnector(this);
   },
-  connect(askWriteAccess) {
-    const googleScope = this.SCOPE_WRITE;
-
-    this.loadingCallback(this, true);
-    let userEmail = null;
-    // Return a Promise with connected username
-    return this.gapi.auth2.getAuthInstance().signIn({
-      scope: googleScope,
-    })
-      .then(currentUser => {
-        userEmail = currentUser.getBasicProfile().getEmail();
-        if (askWriteAccess && !this.canPush) {
-          if (currentUser.hasGrantedScopes(this.SCOPE_WRITE)) {
-            this.canPush = true;
-          } else {
-            return new Promise((resolve, reject) => {
-              currentUser.grant({
-                scope: googleScope,
-              }).then(
-                () => {
-                  this.canPush = true;
-                  resolve(userEmail);
+  authorize(refresh) {
+    return new Promise((resolve, reject) => {
+      try {
+        this.codeClient.callback = (response) => {
+          if (response && response.code) {
+            return getToken(this.CLIENT_ID, this.SECRET_KEY, response.code, window.location.origin)
+              .then(tokenResponse => {
+                if (tokenResponse && tokenResponse.access_token) {
+                  this.gapi.client.setToken(tokenResponse);
+                  resolve(tokenResponse);
                 }
-                ,(error) => {
-                  this.canPush = false;
-                  reject(error);
-                }
-                , this
-              );
-            });
+              });
           }
+        };
+        const cookieSuffix = this.user && this.user.substring(0, this.user.indexOf('@'));
+        const tokenResponse = getCookie(`g_connector_oauth_${cookieSuffix}`);
+        if (refresh && tokenResponse) {
+          const response = JSON.parse(tokenResponse);
+          return refreshToken(this.CLIENT_ID, this.SECRET_KEY, response.refresh_token)
+            .then(refreshTokenResponse => {
+              if (refreshTokenResponse && refreshTokenResponse.access_token) {
+                response.access_token = refreshTokenResponse.access_token;
+                setCookie(`g_connector_oauth_${cookieSuffix}`, JSON.stringify(response), 90);
+                this.gapi.client.setToken(response);
+                this.canPush = this.cientOauth.hasGrantedAllScopes(response, this.SCOPE_WRITE);
+                resolve(response);
+              }
+            });
+        } else if (tokenResponse && this.user) {
+          const response = JSON.parse(tokenResponse);
+          this.gapi.client.setToken(response);
+          resolve(response);
+        } else {
+          this.codeClient.requestCode();
         }
-      }).then(() => userEmail);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  },
+  authenticate() {
+    return new Promise((resolve, reject) => {
+      deleteCookie('g_state');
+      try {
+        this.identity.prompt(notification => {
+          if (notification.getDismissedReason() === 'credential_returned') {
+            resolve();
+          } else
+          if (notification.getDismissedReason() === 'user_cancel') {
+            this.loadingCallback(this, false);
+            this.connectionStatusChangedCallback(this, false, 'user_cancel');
+            resolve();
+          }
+        });
+      } catch (err) {
+        reject(err);
+      }
+    });
+  },
+  connect(askWriteAccess) {
+    this.loadingCallback(this, true);
+    if (askWriteAccess && !this.canPush) {
+      return this.authorize().then(tokenResponse => {
+        if (tokenResponse && tokenResponse.access_token) {
+          this.canPush = this.cientOauth.hasGrantedAllScopes(tokenResponse, this.SCOPE_WRITE);
+          this.identity.prompt();
+          return this.authenticate().then(() => {
+            return new Promise((resolve, reject) => {
+              if (this.credential) {
+                const userEmail = this.credential.email;
+                const cookieSuffix = userEmail.substring(0, userEmail.indexOf('@'));
+                setCookie(`g_connector_oauth_${cookieSuffix}`, JSON.stringify(tokenResponse), 90);
+                resolve(userEmail);
+              } else {
+                reject();
+              }
+            });
+          });
+        }
+      });
+    } else {
+      return this.authenticate().then(() => {
+        return new Promise((resolve, reject) => {
+          if (this.credential) {
+            resolve(this.credential.email);
+          } else {
+            reject();
+          }
+        });
+      });
+    }
   },
   disconnect() {
     this.loadingCallback(this, true);
-    if (this.gapi.auth2.getAuthInstance()) {
-      return this.gapi.auth2.getAuthInstance().signOut();
+    if (this.gapi.client.getToken() && this.cientOauth || this.user) {
+      this.cientOauth.revoke(this.gapi.client.getToken());
+      this.gapi.client.setToken('');
+      if (this.user) {
+        this.identity.revoke(this.user);
+        this.identity.disableAutoSelect();
+      }
+      return Promise.resolve(true);
     } else {
       return Promise.resolve(null);
     }
   },
   getEvents(periodStartDate, periodEndDate) {
     if (this.gapi && this.gapi.client && this.gapi.client.calendar) {
-      const currentUser = this.gapi.auth2.getAuthInstance().currentUser.get();
-
       this.loadingCallback(this, true);
       return new Promise((resolve, reject) => {
-        if (currentUser.hasGrantedScopes(this.SCOPE_WRITE)) {
-          retrieveEvents(this, periodStartDate, periodEndDate)
-            .then(gEvents => resolve(gEvents))
-            .catch(e => {
+        retrieveEvents(this, periodStartDate, periodEndDate)
+          .then(gEvents => resolve(gEvents))
+          .catch(e => {
+            if (e.status === 403 || e.status === 401) {
+              return this.authorize().then((tokenResponse) => {
+                if (tokenResponse && tokenResponse.access_token) {
+                  this.canPush = this.cientOauth.hasGrantedAllScopes(tokenResponse, this.SCOPE_WRITE);
+                  retrieveEvents(this, periodStartDate, periodEndDate)
+                    .then(gEvents => resolve(gEvents))
+                    .catch((e) => {
+                      if (e.status === 403 || e.status === 401) {
+                        return this.authorize(true).then(() => {
+                          retrieveEvents(this, periodStartDate, periodEndDate)
+                            .then(gEvents => resolve(gEvents));
+                        });
+                      } else {
+                        this.loadingCallback(this, false);
+                        reject(e);
+                      }
+                    });
+                }
+              });
+            } else {
               this.loadingCallback(this, false);
               reject(e);
-            });
-        } else {
-          currentUser.grant({
-            scope: this.SCOPE_WRITE
-          }).then(
-            () => retrieveEvents(this, periodStartDate, periodEndDate)
-              .then(gEvents => resolve(gEvents))
-              .catch(e => reject(e))
-            ,(error) => reject(error)
-          );
-        }
+            }
+          });
       }).finally(() => this.loadingCallback(this, false));
     } else {
       return Promise.resolve(null);
@@ -121,30 +197,37 @@ export default {
     return this.saveEvent(event, connectorRecurringEventId, false);
   },
   saveEvent(event, connectorRecurringEventId, deleteEvent) {
-    if (this.gapi && this.gapi.auth2.getAuthInstance()) {
-      const currentUser = this.gapi.auth2.getAuthInstance().currentUser.get();
-
+    if (this.gapi) {
       this.pushing = true;
       return new Promise((resolve, reject) => {
-        if (currentUser.hasGrantedScopes(this.SCOPE_WRITE)) {
-          pushEventToGoogle(this, event, connectorRecurringEventId, deleteEvent)
-            .then(gEvent => {
-              resolve(gEvent);
-            })
-            .catch(error => reject(error));
-        } else {
-          currentUser.grant({
-            scope: this.SCOPE_WRITE
-          }).then(
-            () => pushEventToGoogle(this, event, connectorRecurringEventId, deleteEvent)
-              .then(gEvent => {
-                resolve(gEvent);
-              })
-              .catch(error => reject(error))
-            ,
-            (error) => reject(error)
-          ).catch(error => reject(error));
-        }
+        pushEventToGoogle(this, event, connectorRecurringEventId, deleteEvent)
+          .then(gEvent => {
+            resolve(gEvent);
+          }).catch(error => {
+            if (error.status === 403 || error.status === 401) {
+              return this.authorize().then(() => {
+                pushEventToGoogle(this, event, connectorRecurringEventId, deleteEvent)
+                  .then(gEvent => {
+                    resolve(gEvent);
+                  }).catch(error => {
+                    if (error.status === 403 || error.status === 401) {
+                      return this.authorize(true).then(() => {
+                        pushEventToGoogle(this, event, connectorRecurringEventId, deleteEvent)
+                          .then(gEvent => {
+                            resolve(gEvent);
+                          });
+                      });
+                    } else {
+                      this.loadingCallback(this, false);
+                      reject(error);
+                    }
+                  });
+              });
+            } else {
+              this.loadingCallback(this, false);
+              reject(error);
+            }
+          });
       }).finally(() => this.pushing = false);
     }
     return Promise.reject(new Error('Not connected'));
@@ -183,6 +266,76 @@ function retrieveEvents(connector, periodStartDate, periodEndDate) {
     return events;
   });
 }
+
+function setCookie(name, value, days) {
+  const date = new Date();
+  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+  const expires = `expires=${date.toUTCString()}`;
+  document.cookie = `${name}=${value};${expires};path=/`;
+}
+
+function deleteCookie(name) {
+  document.cookie = `${name}=; Max-Age=0; path=/`;
+}
+
+function getCookie(cname) {
+  const name = `${cname}=`;
+  const decodedCookie = decodeURIComponent(document.cookie);
+  const ca = decodedCookie.split(';');
+  for (const value of ca) {
+    let c = value;
+    while (c.charAt(0) === ' ') {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) === 0) {
+      return c.substring(name.length, c.length);
+    }
+  }
+  return '';
+}
+
+function refreshToken(clientId, clientSecret, refreshToken) {
+  const formData = new FormData();
+  formData.append('client_id', encodeURIComponent(clientId));
+  formData.append('client_secret', encodeURIComponent(clientSecret));
+  formData.append('refresh_token', refreshToken);
+  formData.append('grant_type', 'refresh_token');
+  return fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams(formData).toString(),
+  }).then((resp) => {
+    if (!resp || !resp.ok) {
+      throw new Error('Error while refreshing access token');
+    } else {
+      return resp.json();
+    }
+  });
+}
+
+function getToken(clientId, clientSecret, code, redirect_uri) {
+  const formData = new FormData();
+  formData.append('client_id', encodeURIComponent(clientId));
+  formData.append('client_secret', encodeURIComponent(clientSecret));
+  formData.append('code', code);
+  formData.append('grant_type', 'authorization_code');
+  formData.append('redirect_uri', redirect_uri);
+  return fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams(formData).toString(),
+  }).then((resp) => {
+    if (!resp || !resp.ok) {
+      throw new Error('Error while getting access token');
+    } else {
+      return resp.json();
+    }
+  });
+}
 /**
  * Load Google Connector API javascript and prepare user authentication and
  * authorization process
@@ -192,48 +345,64 @@ function retrieveEvents(connector, periodStartDate, periodEndDate) {
  * @returns {void}
  */
 
-
 function initGoogleConnector(connector) {
-  // Called when the signed in status changes, to update the UI
-  // appropriately. After a sign-in, the API is called.
-  function updateSigninStatus(isSignedIn) {
-    connector.isSignedIn = isSignedIn;
-    try {
-      if (isSignedIn) {
-        const currentUser = connector.gapi.auth2.getAuthInstance().currentUser.get();
-        connector.canPush = currentUser.hasGrantedScopes(connector.SCOPE_WRITE);
-        connector.connectionStatusChangedCallback(connector, {
-          user: currentUser.getBasicProfile().getEmail(),
-          id: currentUser.getId(),
-        });
-      } else {
-        connector.canPush = false;
-        connector.connectionStatusChangedCallback(connector, false);
-      }
-    } finally {
-      connector.loadingCallback(connector, false);
-    }
-  }
-
   connector.loadingCallback(connector, true);
-  window.require(['https://apis.google.com/js/api.js'], () => {
+  window.require(['https://apis.google.com/js/api.js', 'https://accounts.google.com/gsi/client'], () => {
+    connector.identity = google.accounts.id;
+    const cookie = getCookie('g_state');
+    if (cookie && !JSON.parse(cookie).i_t) {
+      connector.isSignedIn = true;
+    }
+    connector.identity.initialize({
+      client_id: connector.CLIENT_ID,
+      callback: (credResponse) => {
+        if (credResponse && credResponse.credential) {
+          const credential = jwt_decode(credResponse.credential);
+          connector.isSignedIn = true;
+          connector.connectionStatusChangedCallback(connector, {
+            user: credential.email,
+            id: credential.sub,
+          });
+          connector.credential = credential;
+        } else {
+          connector.connectionStatusChangedCallback(connector, false);
+        }
+      }
+    });
     connector.gapi = gapi;
-    connector.gapi.load('client:auth2', function() {
+    connector.gapi.load('client', function() {
       gapi.client.init({
-        clientId: connector.CLIENT_ID,
         discoveryDocs: connector.DISCOVERY_DOCS,
-        scope: connector.SCOPE_WRITE,
       }).then(function () {
-        // Listen for sign-in state changes.
-        gapi.auth2.getAuthInstance().isSignedIn.listen(updateSigninStatus);
-
-        // Handle the initial sign-in state.
-        updateSigninStatus(gapi.auth2.getAuthInstance().isSignedIn.get());
+        connector.cientOauth = google.accounts.oauth2;
+        connector.codeClient = connector.cientOauth.initCodeClient({
+          client_id: connector.CLIENT_ID,
+          scope: connector.SCOPE_WRITE,
+          ux_mode: 'popup',
+          callback: (response) => {
+            if (response && response.code) {
+              getToken(connector.CLIENT_ID, connector.SECRET_KEY, response.code, window.location.origin)
+                .then(tokenResponse => {
+                  if (tokenResponse && tokenResponse.access_token) {
+                    connector.canPush = connector.cientOauth.hasGrantedAllScopes(tokenResponse, this.SCOPE_WRITE);
+                    gapi.client.setToken(tokenResponse);
+                    const cookieSuffix = this.user && this.user.substring(0, this.user.indexOf('@'));
+                    setCookie(`g_connector_oauth_${cookieSuffix}`, JSON.stringify(tokenResponse), 90);
+                  }
+                });
+            }
+          },
+          error_callback: (error) => {
+            connector.loadingCallback(connector, false);
+            connector.connectionStatusChangedCallback(connector, false, error);
+          }
+        });
       }, function(error) {
         connector.loadingCallback(connector, false);
         connector.connectionStatusChangedCallback(connector, false, error);
       });
     });
+    connector.loadingCallback(connector, false);
   }, (error) => {
     connector.canConnect = false;
     connector.loadingCallback(connector, false);


### PR DESCRIPTION
Prior to this change, ouath module of gapi is deprecated as alerted by google and need to be replaced, This PR refactors the google connector to use gsi (google service identity) for oauth manipulation part instead of the deprecated gapi oauth.