### PR TITLE
fix: Google Agenda Connection must be redo each week on Brave - EXO-62389

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
@@ -64,6 +64,9 @@ export default {
         };
         const cookieSuffix = this.user && this.user.substring(0, this.user.indexOf('@'));
         const tokenResponse = getCookie(`g_connector_oauth_${cookieSuffix}`);
+        if (tokenResponse) {
+          setCookie(`g_connector_oauth_${cookieSuffix}`, JSON.stringify(tokenResponse), 90);
+        }
         if (refresh && tokenResponse) {
           const response = JSON.parse(tokenResponse);
           return refreshToken(this.CLIENT_ID, this.SECRET_KEY, response.refresh_token)


### PR DESCRIPTION
Before this fix, the cookie created for the google agenda synchronization is created with a livetime of 7 days due to brave limitation So, After a week, the connection with the agenda is KO beacause the cookie is no more valid

This fix refresh the cookie each time the integration is used, so it can be used more than one week before expiration