### PR TITLE
fix: Exchange connector make a request related to inbox to check credentials - EXO-63702

### DIFF
--- a/agenda-connectors-api/src/main/java/org/exoplatform/agendaconnector/model/ExchangeUserSetting.java
+++ b/agenda-connectors-api/src/main/java/org/exoplatform/agendaconnector/model/ExchangeUserSetting.java
@@ -28,4 +28,6 @@ public class ExchangeUserSetting {
   private String username;
 
   private String password;
+
+  private boolean credentialChecked;
 }

--- a/agenda-connectors-packaging/pom.xml
+++ b/agenda-connectors-packaging/pom.xml
@@ -26,6 +26,10 @@
       <scope>provided</scope>
       <type>war</type>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.ws</groupId>
+      <artifactId>jaxws-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <finalName>agenda-connectors-addon</finalName>

--- a/agenda-connectors-packaging/src/main/assemblies/assembly.xml
+++ b/agenda-connectors-packaging/src/main/assemblies/assembly.xml
@@ -22,6 +22,7 @@
       <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>${project.groupId}:*:jar</include>
+        <include>javax.xml.ws:*:jar</include>
       </includes>
       <scope>provided</scope>
       <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>

--- a/agenda-connectors-services/pom.xml
+++ b/agenda-connectors-services/pom.xml
@@ -9,7 +9,6 @@
   <name>eXo Agenda Connectors - Services</name>
   <properties>
     <exo.test.coverage.ratio>0.3</exo.test.coverage.ratio>
-    <com.microsoft.ews.version>2.0</com.microsoft.ews.version>
   </properties>
   <dependencies>
     <dependency>
@@ -46,8 +45,10 @@
     <dependency>
       <groupId>com.microsoft.ews-java-api</groupId>
       <artifactId>ews-java-api</artifactId>
-      <version>${com.microsoft.ews.version}</version>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.ws</groupId>
+      <artifactId>jaxws-api</artifactId>
     </dependency>
     <!-- Test -->
     <dependency>

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/storage/ExchangeConnectorStorage.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/storage/ExchangeConnectorStorage.java
@@ -46,6 +46,9 @@ public class ExchangeConnectorStorage {
                             ExchangeConnectorUtils.EXCHANGE_CONNECTOR_SETTING_SCOPE,
                             ExchangeConnectorUtils.EXCHANGE_PASSWORD_KEY,
                             SettingValue.create(encodedPassword));
+    this.settingService.set(Context.USER.id(String.valueOf(userIdentityId)),
+                            ExchangeConnectorUtils.EXCHANGE_CONNECTOR_SETTING_SCOPE,
+                            ExchangeConnectorUtils.EXCHANGE_CREDENTIAL_CHECKED,SettingValue.create(exchangeUserSetting.isCredentialChecked()));
   }
 
   public ExchangeUserSetting getExchangeSetting(long userIdentityId) {
@@ -56,6 +59,10 @@ public class ExchangeConnectorStorage {
     SettingValue<?> password = this.settingService.get(Context.USER.id(String.valueOf(userIdentityId)),
             ExchangeConnectorUtils.EXCHANGE_CONNECTOR_SETTING_SCOPE,
             ExchangeConnectorUtils.EXCHANGE_PASSWORD_KEY);
+    SettingValue<?> credentialChecked = this.settingService.get(Context.USER.id(String.valueOf(userIdentityId)),
+                                                       ExchangeConnectorUtils.EXCHANGE_CONNECTOR_SETTING_SCOPE,
+                                                       ExchangeConnectorUtils.EXCHANGE_CREDENTIAL_CHECKED);
+
 
     ExchangeUserSetting exchangeUserSetting = new ExchangeUserSetting();
     if (username != null) {
@@ -64,6 +71,11 @@ public class ExchangeConnectorStorage {
     if (username != null) {
       String decodePassword = ExchangeConnectorUtils.decode((String) password.getValue());
       exchangeUserSetting.setPassword(decodePassword);
+    }
+    if(credentialChecked!=null) {
+      exchangeUserSetting.setCredentialChecked((boolean) credentialChecked.getValue());
+    } else {
+      exchangeUserSetting.setCredentialChecked(false);
     }
     return exchangeUserSetting;
   }
@@ -76,6 +88,9 @@ public class ExchangeConnectorStorage {
     this.settingService.remove(Context.USER.id(String.valueOf(userIdentityId)),
                                ExchangeConnectorUtils.EXCHANGE_CONNECTOR_SETTING_SCOPE,
                                ExchangeConnectorUtils.EXCHANGE_PASSWORD_KEY);
+    this.settingService.remove(Context.USER.id(String.valueOf(userIdentityId)),
+                               ExchangeConnectorUtils.EXCHANGE_CONNECTOR_SETTING_SCOPE,
+                               ExchangeConnectorUtils.EXCHANGE_CREDENTIAL_CHECKED);
   }
 
   public  void deleteRemoteEvent(long eventId, long userIdentityId){

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,9 @@
     <addon.exo.agenda.version>1.3.x-SNAPSHOT</addon.exo.agenda.version>
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
+
+    <com.microsoft.ews.version>2.0</com.microsoft.ews.version>
+    <javax.xml.ws.version>2.3.1</javax.xml.ws.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -88,6 +91,18 @@
         <version>${project.version}</version>
         <scope>provided</scope>
         <type>zip</type>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.ws</groupId>
+        <artifactId>jaxws-api</artifactId>
+        <scope>provided</scope>
+        <version>${javax.xml.ws.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.ews-java-api</groupId>
+        <artifactId>ews-java-api</artifactId>
+        <version>${com.microsoft.ews.version}</version>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Before this fix, the exchange connector make a request related to inbox to check credentials : getInboxRules As our connector speaks about calendar, it is better to make a request linked to calendar stuff. In addition the request to get inbox rules seems not working with old Exchange version. Another problem is a class not found exception with java17 due to missing jar Finally, the request to check credential is redo each time we pull events informations.

This fix
- add the missing jar, so that we have not more class not found exception
- Add a mechanism to store the information if user credentials are validated, so that the check request is not more run if not needed
- Change the check request from getInboxRules to findItems