### PR TITLE
fix: Refactor agenda google connector - EXO-65042

### DIFF
--- a/agenda-connectors-api/src/main/java/org/exoplatform/agendaconnector/service/GoogleConnectorService.java
+++ b/agenda-connectors-api/src/main/java/org/exoplatform/agendaconnector/service/GoogleConnectorService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.agendaconnector.service;
+
+public interface GoogleConnectorService {
+
+  /**
+   * Saves google connector token response
+   *
+   * @param userName current user name
+   * @param token token string
+   */
+  void saveTokenResponse(String userName, String token);
+
+  /**
+   * Get the stored google connector token response
+   *
+   * @param userName current username
+   * @return token string
+   */
+  String getTokenResponse(String userName);
+
+  /**
+   * Remove stored google token response
+   * @param userName current username
+   */
+  void removeTokenResponse(String userName);
+
+}

--- a/agenda-connectors-services/pom.xml
+++ b/agenda-connectors-services/pom.xml
@@ -36,6 +36,29 @@
       <artifactId>social-component-service</artifactId>
        <scope>provided</scope>
     </dependency>
+
+    <!-- Google -->
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-plus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-oauth2</artifactId>
+    </dependency>
+
     <!--swagger-->
     <dependency>
       <groupId>io.swagger.core.v3</groupId>

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/rest/GoogleConnectorRest.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/rest/GoogleConnectorRest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2023 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.agendaconnector.rest;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleRefreshTokenRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.agenda.model.RemoteProvider;
+import org.exoplatform.agenda.service.AgendaRemoteEventService;
+import org.exoplatform.agendaconnector.service.GoogleConnectorService;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.rest.resource.ResourceContainer;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.exoplatform.services.security.ConversationState;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+
+@Path("/v1/gconnector")
+@Tag(name = "/gconnector", description = "Manages Google connector tokens and authorization")
+public class GoogleConnectorRest implements ResourceContainer {
+
+  private static final Log               LOG = ExoLogger.getLogger(GoogleConnectorRest.class);
+
+  private final AgendaRemoteEventService agendaRemoteEventService;
+
+  private final GoogleConnectorService   googleConnectorService;
+
+  public GoogleConnectorRest(AgendaRemoteEventService agendaRemoteEventService, GoogleConnectorService googleConnectorService) {
+    this.agendaRemoteEventService = agendaRemoteEventService;
+    this.googleConnectorService = googleConnectorService;
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  @Path("/oauth2callback")
+  @Operation(summary = "Exchange an authorization code by an access and refresh token",
+             description = "Exchange an authorization code by an access and refresh token", method = "POST")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "400", description = "Invalid query input"),
+      @ApiResponse(responseCode = "404", description = "Not found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error"), })
+  public Response requestToken(@Parameter(description = "authorization code") @FormParam("code") String code,
+                           @Parameter(description = "grant type") @FormParam("grantType") String grantType,
+                           @Parameter(description = "redirect uri") @FormParam("redirectUri") String redirectUri,
+                           @Parameter(description = "grant scopes") @FormParam("scopes") String scopes) {
+    if (StringUtils.isBlank(code)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("authorization code is mandatory").build();
+    }
+    if (StringUtils.isBlank(grantType)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("grantType is mandatory").build();
+    }
+    String userName = ConversationState.getCurrent().getIdentity().getUserId();
+    Optional<RemoteProvider> provider = getGoogleRemoteProvider();
+    if (provider.isEmpty()) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    try {
+      RemoteProvider googleRemoteProvider = provider.get();
+      GoogleAuthorizationCodeFlow.Builder flow = new GoogleAuthorizationCodeFlow.Builder(new NetHttpTransport(),
+                                                                                         new GsonFactory(),
+                                                                                         googleRemoteProvider.getApiKey(),
+                                                                                         googleRemoteProvider.getSecretKey(),
+                                                                                         Collections.singleton(scopes));
+      flow.setAccessType("offline");
+      GoogleAuthorizationCodeFlow authorizationCodeFlow = flow.build();
+      GoogleTokenResponse response = authorizationCodeFlow.newTokenRequest(code)
+                                                          .setGrantType(grantType)
+                                                          .setRedirectUri(redirectUri)
+                                                          .execute();
+      googleConnectorService.saveTokenResponse(userName, response.toString());
+      return Response.ok(response).build();
+    } catch (Exception e) {
+      LOG.error("Error while requesting refresh and access tokens", e);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  @Path("/refreshaccess")
+  @Operation(summary = "Refreshes an existing access token using a stored refresh token",
+          description = "Refreshes an existing access token using a stored refresh token", method = "POST")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+          @ApiResponse(responseCode = "400", description = "Invalid query input"),
+          @ApiResponse(responseCode = "404", description = "Not found"),
+          @ApiResponse(responseCode = "500", description = "Internal server error"), })
+  public Response refreshToken(@Parameter(description = "grant type") @FormParam("grantType") String grantType) {
+
+    if (StringUtils.isBlank(grantType)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("grantType is mandatory").build();
+    }
+    String userName = ConversationState.getCurrent().getIdentity().getUserId();
+    Optional<RemoteProvider> provider = getGoogleRemoteProvider();
+    if (provider.isEmpty()) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    try {
+      RemoteProvider googleRemoteProvider = provider.get();
+      String tokenResponse = googleConnectorService.getTokenResponse(userName);
+      JSONParser parser = new JSONParser();
+      Map<?, ?> responseMap = (Map<?, ?>) parser.parse(tokenResponse);
+      String refreshToken = (String) responseMap.get("refresh_token");
+      GoogleTokenResponse response = new GoogleRefreshTokenRequest(new NetHttpTransport(),
+                                                                   new GsonFactory(),
+                                                                   refreshToken,
+                                                                   googleRemoteProvider.getApiKey(),
+                                                                   googleRemoteProvider.getSecretKey()).execute();
+      response.set("refresh_token", refreshToken);
+      googleConnectorService.saveTokenResponse(userName, response.toString());
+      return Response.ok(response).build();
+    } catch (Exception e) {
+      LOG.error("Error while refreshing the access tokens", e);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  @Path("/token")
+  @Operation(summary = "Get stored token response", description = "Get stored token response", method = "GET")
+  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "404", description = "Not found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error"), })
+  public Response getStoredToken() {
+    String userName = ConversationState.getCurrent().getIdentity().getUserId();
+    try {
+      String tokenResponse = googleConnectorService.getTokenResponse(userName);
+      if (tokenResponse == null) {
+        return Response.status(Response.Status.NOT_FOUND).build();
+      }
+      JSONParser parser = new JSONParser();
+      JSONObject response = (JSONObject) parser.parse(tokenResponse);
+      return Response.ok(response).build();
+    } catch (Exception e) {
+      LOG.error("Error while getting sored token", e);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @DELETE
+  @Produces(MediaType.APPLICATION_JSON)
+  @RolesAllowed("users")
+  @Path("/token")
+  @Operation(summary = "Remove stored token response", description = "Remove stored token response", method = "DELETE")
+  @ApiResponses(value = {
+          @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+          @ApiResponse(responseCode = "500", description = "Internal server error"), })
+  public Response removeStoredToken() {
+    String userName = ConversationState.getCurrent().getIdentity().getUserId();
+    try {
+      googleConnectorService.removeTokenResponse(userName);
+      return Response.ok().build();
+    } catch (Exception e) {
+      LOG.error("Error while getting stored token", e);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  private Optional<RemoteProvider> getGoogleRemoteProvider() {
+    return agendaRemoteEventService.getRemoteProviders()
+                                   .stream()
+                                   .filter(remoteProvider -> remoteProvider.getName().equals("agenda.googleCalendar"))
+                                   .findFirst();
+  }
+}

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/GoogleConnectorServiceImpl.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/GoogleConnectorServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+package org.exoplatform.agendaconnector.service;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+
+public class GoogleConnectorServiceImpl implements GoogleConnectorService {
+
+  private static final Scope   APP_SCOPE                     = Scope.APPLICATION.id("gConnectorRefreshToken");
+
+  private static final String  G_CONNECTOR_REFRESH_TOKEN_KEY = "gConnectorRefreshTokenKey";
+
+  private final SettingService settingService;
+
+  public GoogleConnectorServiceImpl(SettingService settingService) {
+    this.settingService = settingService;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void saveTokenResponse(String userName, String token) {
+    if (userName == null) {
+      throw new IllegalArgumentException("username is mandatory");
+    }
+    if (token == null) {
+      throw new IllegalArgumentException("token object is mandatory");
+    }
+    settingService.set(Context.USER.id(userName), APP_SCOPE, G_CONNECTOR_REFRESH_TOKEN_KEY, SettingValue.create(token));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getTokenResponse(String userName) {
+    if (userName == null) {
+      throw new IllegalArgumentException("username is mandatory");
+    }
+    SettingValue<?> tokenResponse = settingService.get(Context.USER.id(userName), APP_SCOPE, G_CONNECTOR_REFRESH_TOKEN_KEY);
+    if (tokenResponse == null) {
+      return null;
+    }
+    return (String) tokenResponse.getValue();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void removeTokenResponse(String userName) {
+    if (userName == null) {
+      throw new IllegalArgumentException("username is mandatory");
+    }
+    settingService.remove(Context.USER.id(userName), APP_SCOPE, G_CONNECTOR_REFRESH_TOKEN_KEY);
+  }
+}

--- a/agenda-connectors-services/src/main/resources/conf/portal/configuration.xml
+++ b/agenda-connectors-services/src/main/resources/conf/portal/configuration.xml
@@ -27,4 +27,11 @@
   <component>
     <type>org.exoplatform.agendaconnector.storage.ExchangeConnectorStorage</type>
   </component>
+  <component>
+    <type>org.exoplatform.agendaconnector.rest.GoogleConnectorRest</type>
+  </component>
+  <component>
+    <key>org.exoplatform.agendaconnector.service.GoogleConnectorService</key>
+    <type>org.exoplatform.agendaconnector.service.GoogleConnectorServiceImpl</type>
+  </component>
 </configuration>

--- a/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/GoogleConnectorServiceImplTest.java
+++ b/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/GoogleConnectorServiceImplTest.java
@@ -1,0 +1,58 @@
+package org.exoplatform.agendaconnector.service;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class GoogleConnectorServiceImplTest {
+
+  private SettingService         settingService;
+
+  private GoogleConnectorService googleConnectorService;
+
+  private static final Scope     APP_SCOPE                     = Scope.APPLICATION.id("gConnectorRefreshToken");
+
+  private static final String    G_CONNECTOR_REFRESH_TOKEN_KEY = "gConnectorRefreshTokenKey";
+
+  @Before
+  public void setUp() throws Exception {
+    settingService = mock(SettingService.class);
+    googleConnectorService = new GoogleConnectorServiceImpl(settingService);
+  }
+
+  @Test
+  public void saveTokenResponse() {
+    Throwable exception =
+                        assertThrows(IllegalArgumentException.class, () -> googleConnectorService.saveTokenResponse(null, null));
+    assertEquals("username is mandatory", exception.getMessage());
+    exception = assertThrows(IllegalArgumentException.class, () -> googleConnectorService.saveTokenResponse("user", null));
+    assertEquals("token object is mandatory", exception.getMessage());
+    googleConnectorService.saveTokenResponse("user", "token");
+    verify(settingService, times(1)).set(any(Context.class), any(Scope.class), anyString(), any());
+
+  }
+
+  @Test
+  public void getTokenResponse() {
+    Throwable exception =
+                        assertThrows(IllegalArgumentException.class, () -> googleConnectorService.saveTokenResponse(null, null));
+    assertEquals("username is mandatory", exception.getMessage());
+    googleConnectorService.getTokenResponse("user");
+    verify(settingService, times(1)).get(any(Context.class), any(Scope.class), anyString());
+  }
+
+  @Test
+  public void removeTokenResponse() {
+    Throwable exception =
+                        assertThrows(IllegalArgumentException.class, () -> googleConnectorService.saveTokenResponse(null, null));
+    assertEquals("username is mandatory", exception.getMessage());
+    googleConnectorService.removeTokenResponse("user");
+    verify(settingService, times(1)).remove(any(Context.class), any(Scope.class), anyString());
+  }
+}

--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
@@ -23,7 +23,6 @@ export default {
   isOauth: true,
   mandatorySecretKey: true,
   CLIENT_ID: null,
-  SECRET_KEY: null,
   DISCOVERY_DOCS: ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'],
   SCOPE_WRITE: 'https://www.googleapis.com/auth/calendar.events',
   canConnect: true,
@@ -32,12 +31,11 @@ export default {
   isSignedIn: false,
   pushing: false,
   rank: 10,
-  init(connectionStatusChangedCallback, loadingCallback, apiKey, secretKey) {
-    if (!apiKey || !secretKey) {
-      throw new Error('Google connector can\'t be enabled with empty Client API Key or empty Client Secret Key.');
+  init(connectionStatusChangedCallback, loadingCallback, apiKey) {
+    if (!apiKey) {
+      throw new Error('Google connector can\'t be enabled with empty Client API Key.');
     }
     this.CLIENT_ID = apiKey;
-    this.SECRET_KEY = secretKey;
     // Already initialized
     if (this.initialized) {
       return;
@@ -53,7 +51,7 @@ export default {
       try {
         this.codeClient.callback = (response) => {
           if (response && response.code) {
-            return getToken(this.CLIENT_ID, this.SECRET_KEY, response.code, window.location.origin)
+            return requestToken(response.code, response.scope, window.location.origin)
               .then(tokenResponse => {
                 if (tokenResponse && tokenResponse.access_token) {
                   this.gapi.client.setToken(tokenResponse);
@@ -62,29 +60,27 @@ export default {
               });
           }
         };
-        const cookieSuffix = this.user && this.user.substring(0, this.user.indexOf('@'));
-        const tokenResponse = getCookie(`g_connector_oauth_${cookieSuffix}`);
-        if (tokenResponse) {
-          setCookie(`g_connector_oauth_${cookieSuffix}`, tokenResponse, 90);
-          const g_stateCookie = getCookie('g_state');
-          setCookie('g_state', g_stateCookie, 90);
-        }
-        if (refresh && tokenResponse) {
-          const response = JSON.parse(tokenResponse);
-          return refreshToken(this.CLIENT_ID, this.SECRET_KEY, response.refresh_token)
-            .then(refreshTokenResponse => {
-              if (refreshTokenResponse && refreshTokenResponse.access_token) {
-                response.access_token = refreshTokenResponse.access_token;
-                setCookie(`g_connector_oauth_${cookieSuffix}`, JSON.stringify(response), 90);
-                this.gapi.client.setToken(response);
-                this.canPush = this.cientOauth.hasGrantedAllScopes(response, this.SCOPE_WRITE);
-                resolve(response);
-              }
-            });
-        } else if (tokenResponse && this.user) {
-          const response = JSON.parse(tokenResponse);
-          this.gapi.client.setToken(response);
-          resolve(response);
+        if (refresh) {
+          return refreshToken().then(refreshTokenResponse => {
+            if (refreshTokenResponse && refreshTokenResponse.access_token) {
+              this.gapi.client.setToken(refreshTokenResponse);
+              this.canPush = this.cientOauth.hasGrantedAllScopes(refreshTokenResponse, this.SCOPE_WRITE);
+              resolve(refreshTokenResponse);
+            }
+          });
+        } else if (this.user) {
+          return getStoredToken().then(tokenResponse => {
+            if (tokenResponse && tokenResponse.access_token) {
+              this.gapi.client.setToken(tokenResponse);
+              this.canPush = this.cientOauth.hasGrantedAllScopes(tokenResponse, this.SCOPE_WRITE);
+              this.gapi.client.setToken(tokenResponse);
+              resolve(tokenResponse);
+            }
+          }).catch((error) => {
+            if (error.status === 404) {
+              this.codeClient.requestCode();
+            }
+          });
         } else {
           this.codeClient.requestCode();
         }
@@ -123,9 +119,6 @@ export default {
             return new Promise((resolve, reject) => {
               if (this.credential) {
                 const userEmail = this.credential.email;
-                const cookieSuffix = userEmail.substring(0, userEmail.indexOf('@'));
-
-                setCookie(`g_connector_oauth_${cookieSuffix}`, JSON.stringify(tokenResponse), 90);
                 resolve(userEmail);
               } else {
                 reject();
@@ -148,17 +141,17 @@ export default {
   },
   disconnect() {
     this.loadingCallback(this, true);
-    if (this.gapi.client.getToken() && this.cientOauth || this.user) {
-      this.cientOauth.revoke(this.gapi.client.getToken());
-      this.gapi.client.setToken('');
-      if (this.user) {
-        this.identity.revoke(this.user);
-        this.identity.disableAutoSelect();
+    return removeToken().then(() => {
+      if (this.gapi.client.getToken() && this.cientOauth || this.user) {
+        this.cientOauth.revoke(this.gapi.client.getToken());
+        this.gapi.client.setToken('');
+        if (this.user) {
+          this.identity.revoke(this.user);
+          this.identity.disableAutoSelect();
+        }
       }
-      return Promise.resolve(true);
-    } else {
-      return Promise.resolve(null);
-    }
+    });
+
   },
   getEvents(periodStartDate, periodEndDate) {
     if (this.gapi && this.gapi.client && this.gapi.client.calendar) {
@@ -273,40 +266,25 @@ function retrieveEvents(connector, periodStartDate, periodEndDate) {
   });
 }
 
-function setCookie(name, value, days) {
-  const date = new Date();
-  date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-  const expires = `expires=${date.toUTCString()}`;
-  document.cookie = `${name}=${value};${expires};path=/`;
-}
-
 function deleteCookie(name) {
   document.cookie = `${name}=; Max-Age=0; path=/`;
 }
 
-function getCookie(cname) {
-  const name = `${cname}=`;
-  const decodedCookie = decodeURIComponent(document.cookie);
-  const ca = decodedCookie.split(';');
-  for (const value of ca) {
-    let c = value;
-    while (c.charAt(0) === ' ') {
-      c = c.substring(1);
+function removeToken() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/gconnector/token`, {
+    credentials: 'include',
+    method: 'DELETE'
+  }).then((resp) => {
+    if (resp && !resp.ok) {
+      throw new Error('Error while removing stored token');
     }
-    if (c.indexOf(name) === 0) {
-      return c.substring(name.length, c.length);
-    }
-  }
-  return '';
+  });
 }
 
-function refreshToken(clientId, clientSecret, refreshToken) {
+function refreshToken() {
   const formData = new FormData();
-  formData.append('client_id', encodeURIComponent(clientId));
-  formData.append('client_secret', encodeURIComponent(clientSecret));
-  formData.append('refresh_token', refreshToken);
   formData.append('grant_type', 'refresh_token');
-  return fetch('https://oauth2.googleapis.com/token', {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/gconnector/refreshaccess`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -321,14 +299,25 @@ function refreshToken(clientId, clientSecret, refreshToken) {
   });
 }
 
-function getToken(clientId, clientSecret, code, redirect_uri) {
+function getStoredToken() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/gconnector/token`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then((resp) => {
+    if (!resp?.ok) {
+      throw resp;
+    } else {
+      return resp.json();
+    }
+  });
+}
+function requestToken(code, scopes, redirect_uri) {
   const formData = new FormData();
-  formData.append('client_id', encodeURIComponent(clientId));
-  formData.append('client_secret', encodeURIComponent(clientSecret));
-  formData.append('code', code);
-  formData.append('grant_type', 'authorization_code');
-  formData.append('redirect_uri', redirect_uri);
-  return fetch('https://oauth2.googleapis.com/token', {
+  formData.append('code',code);
+  formData.append('scopes',scopes);
+  formData.append('grantType', 'authorization_code');
+  formData.append('redirectUri', redirect_uri);
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/gconnector/oauth2callback`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -336,9 +325,17 @@ function getToken(clientId, clientSecret, code, redirect_uri) {
     body: new URLSearchParams(formData).toString(),
   }).then((resp) => {
     if (!resp || !resp.ok) {
-      throw new Error('Error while getting access token');
+      throw new Error('Error while requesting access token');
     } else {
       return resp.json();
+    }
+  });
+}
+
+function checkUserStatus(connector) {
+  getStoredToken().then(token => {
+    if (connector.user && token?.access_token) {
+      connector.isSignedIn = true;
     }
   });
 }
@@ -357,6 +354,7 @@ function initGoogleConnector(connector) {
     connector.identity = google.accounts.id;
     connector.identity.initialize({
       client_id: connector.CLIENT_ID,
+      select_by: 'user',
       callback: (credResponse) => {
         if (credResponse && credResponse.credential) {
           const credential = jwt_decode(credResponse.credential);
@@ -376,29 +374,12 @@ function initGoogleConnector(connector) {
       gapi.client.init({
         discoveryDocs: connector.DISCOVERY_DOCS,
       }).then(function () {
-        const cookie = getCookie('g_state');
-        if (cookie && !JSON.parse(cookie).i_t) {
-          connector.isSignedIn = true;
-        }
+        checkUserStatus(connector);
         connector.cientOauth = google.accounts.oauth2;
         connector.codeClient = connector.cientOauth.initCodeClient({
           client_id: connector.CLIENT_ID,
           scope: connector.SCOPE_WRITE,
           ux_mode: 'popup',
-          callback: (response) => {
-            if (response && response.code) {
-              getToken(connector.CLIENT_ID, connector.SECRET_KEY, response.code, window.location.origin)
-                .then(tokenResponse => {
-                  if (tokenResponse && tokenResponse.access_token) {
-                    connector.canPush = connector.cientOauth.hasGrantedAllScopes(tokenResponse, this.SCOPE_WRITE);
-                    gapi.client.setToken(tokenResponse);
-                    const cookieSuffix = this.user && this.user.substring(0, this.user.indexOf('@'));
-
-                    setCookie(`g_connector_oauth_${cookieSuffix}`, JSON.stringify(tokenResponse), 90);
-                  }
-                });
-            }
-          },
           error_callback: (error) => {
             connector.loadingCallback(connector, false);
             connector.connectionStatusChangedCallback(connector, false, error);


### PR DESCRIPTION
Prior to this change, the secert key was needed to be able to use the google api, in the first implementation the seceret_key was exposed in front side  in js files which is considered as a security issue.
This PR changes the way to get the access and refresh tokens by implementing a sever side part which will be responsible about getting, refreshing and storing tokens