### PR TITLE
fix: fix sent grant type parameter name in refresh token function - EXO-65042

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
@@ -283,7 +283,7 @@ function removeToken() {
 
 function refreshToken() {
   const formData = new FormData();
-  formData.append('grant_type', 'refresh_token');
+  formData.append('grantType', 'refresh_token');
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/gconnector/refreshaccess`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Prior to this change, refreshing token is not ok because the sent grant type parameter in the fetch call doesn't fit the parameter name set in the rest endpoint which caused an issue. 
This PR fixes the issue by setting the right fit name in the http call