### PR TITLE
fix: renew JWT token to avoid its expiration - EXO-65633

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
@@ -84,7 +84,7 @@ export default {
     return this.officeApi.loginPopup(this.loginRequest)
       .then(loginResponse => getTokenPopup(this, loginResponse))
       .then(tokenObject => {
-        const username = tokenObject && tokenObject.account && tokenObject.account.username;
+        const username = tokenObject?.account?.username;
         this.user = username;
         this.canPush = askWriteAccess;
 
@@ -195,6 +195,7 @@ function initOfficeConnector(connector) {
         redirectUri: window.location.origin,
         account: currentUser.username,
         scopes: connector.CALENDAR_WRITE_SCOPE,
+        forceRefresh: true,
       };
 
       return officeApi.acquireTokenSilent(request)

--- a/agenda-connectors-webapp/webpack.watch.js
+++ b/agenda-connectors-webapp/webpack.watch.js
@@ -16,5 +16,5 @@ module.exports = merge(webpackProductionConfig, {
     path: path.resolve(`${exoServerPath}/webapps/${app}/`)
   },
   mode: 'development',
-  devtool: 'inline-source-map'
+  devtool: 'eval-source-map'
 })


### PR DESCRIPTION
Every one hour, the MS Office connector fails to connect to outlook agenda to retrieve events. This is because the token expires and is not renewed as expected due to a technical limitation on the MSAL.js as detailed in https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4206
The current fix forces the renewal of the token on each usage of the MSAD.js 