### PR TITLE
fix: after a page refresh, events are not pushed to Google Calendar - EXO-65485

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
@@ -336,6 +336,7 @@ function checkUserStatus(connector) {
   getStoredToken().then(token => {
     if (connector.user && token?.access_token) {
       connector.isSignedIn = true;
+      connector.canPush = connector.cientOauth.hasGrantedAllScopes(token, connector.SCOPE_WRITE);
     }
   });
 }


### PR DESCRIPTION
After a page reload, events are not pushed to Google calendar when they are created inside Agenda app.
The issue is caused by the fact that after retriving the token from storage, the authentication is not redone and the canPush property is not recalculated again.
The fix rechecks the permission, of the current user / connector configuration once the token is retrieved .