### PR TITLE
fix: use local storage for storing MS tokens to avoid frequent logins - EXO-65633 

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
@@ -26,7 +26,7 @@ export default {
       postLogoutRedirectUri: window.location.origin,
     },
     cache: {
-      cacheLocation: 'sessionStorage', // This configures where your cache will be stored
+      cacheLocation: 'localStorage', // This configures where your cache will be stored
       storeAuthStateInCookie: true, // Set this to 'true' if you are having issues on IE11 or Edge
     }
   },


### PR DESCRIPTION
Priori to this fix, users were requested to login each few moments because their tokens get expired soon. This change will cache tokens in local storage of the browser instead of the session to make them reusable and enhance the UX https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/caching.md