### PR TITLE
fix: Access to edit page layout is not working.

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/agenda-connectors-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <gatein-resources xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_resources_1_4 http://www.exoplatform.org/xml/ns/gatein_resources_1_4" xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_4">
-  <portal-skin>
-    <skin-name>Enterprise</skin-name>
-    <css-path>/skin/css/agenda-connectors.css</css-path>
-    <css-priority>10</css-priority>
-  </portal-skin>
   <module>
     <name>AgendaConnectorsExtensions</name>
     <load-group>AgendaConnectorsGRP</load-group>

--- a/agenda-connectors-webapp/src/main/webapp/skin/less/agenda-connectors.less
+++ b/agenda-connectors-webapp/src/main/webapp/skin/less/agenda-connectors.less
@@ -1,2 +1,0 @@
-@import "variables.less";
-@import "mixins.less";


### PR DESCRIPTION
Before this fix, a lot of page were not working due to missing css Core-min.js in eXo Skin In fact, this css was not load because as we didnt add skin-module in gatein-resources for the agenda-connector css, it automatically take 'Core', and erase the eXkin one. This commit completly remove the css definition as the less file is empty.