### PR TITLE
fix: Exchange events synchronization issue after server restart - EXO-67725

### DIFF
--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/storage/ExchangeConnectorStorage.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/storage/ExchangeConnectorStorage.java
@@ -72,8 +72,8 @@ public class ExchangeConnectorStorage {
       String decodePassword = ExchangeConnectorUtils.decode((String) password.getValue());
       exchangeUserSetting.setPassword(decodePassword);
     }
-    if(credentialChecked!=null) {
-      exchangeUserSetting.setCredentialChecked((boolean) credentialChecked.getValue());
+    if (credentialChecked != null) {
+      exchangeUserSetting.setCredentialChecked(Boolean.valueOf(String.valueOf(credentialChecked.getValue())));
     } else {
       exchangeUserSetting.setCredentialChecked(false);
     }


### PR DESCRIPTION
Before this change, a log error for casting a boolean to String while retrieving the user connecter setting
after this change, the setting is forced to be cast into the Boolean object