### PR TITLE
fix:fix update an event to  recurrent events only one event is displayed on exchange agenda - EXO-68948

### DIFF
--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
@@ -205,6 +205,7 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
         ZonedDateTime endDate = AgendaDateUtils.parseRFC3339ToZonedDateTime(event.getEnd(), userTimeZone);
         appointment.setStart(AgendaDateUtils.toDate(startDate));
         appointment.setEnd(AgendaDateUtils.toDate(endDate));
+        appointment.setRecurrence(getEventRecurrence(event.getId()));
         appointment.update(ConflictResolutionMode.AlwaysOverwrite, SendInvitationsOrCancellationsMode.SendToAllAndSaveCopy);
       }
     } catch (ServiceLocalException e) {

--- a/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImplTest.java
+++ b/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImplTest.java
@@ -213,6 +213,8 @@ public class ExchangeConnectorServiceImplTest {
     eventEntity.setEnd(AgendaDateUtils.toRFC3339Date(endDate));
     eventEntity.setRemoteProviderId(1);
     eventEntity.setRemoteProviderName("agenda.exchangeCalendar");
+    Event event = new Event();
+    when(agendaEventService.getEventById(eventEntity.getId())).thenReturn(event);
     exchangeConnectorService.pushEventToExchange(1, eventEntity, dstTimeZone);
     // Then
     verify(appointment, times(1)).update(any(), any());


### PR DESCRIPTION
before this change, when a event is updated only one event is updated  into the exchange data without any recurrence info causing the non-display of all the events
After this change, the recurrence info is updated to the event and all recurrent events are displayed