### PR TITLE
fix: fix monthly/yearly events are ko with outlookConnector - EXO-69013

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
@@ -543,7 +543,14 @@ function buildConnectorEvent(event) {
       connectorEvent.recurrence.pattern.firstDayOfWeek = 'monday';
     }
     if (daysOfMonth) {
-      connectorEvent.recurrence.pattern.daysOfMonth = daysOfMonth;
+      if (recurrenceType === 'absoluteMonthly') {
+        connectorEvent.recurrence.pattern.dayOfMonth = daysOfMonth[0];
+      } else if (recurrenceType === 'absoluteYearly') {
+        connectorEvent.recurrence.pattern.dayOfMonth = daysOfMonth[0];
+        connectorEvent.recurrence.pattern.month = event.recurrence?.byMonth[0];
+      } else {
+        connectorEvent.recurrence.pattern.daysOfMonth = daysOfMonth;
+      }
     }
     if (event.recurrence.count) {
       connectorEvent.recurrence.range.numberOfOccurrences = event.recurrence.count;


### PR DESCRIPTION
Before this change, Monthly and Yearly events are not added to the outlook agenda since the recurrent event properties are not well set and some ones are missed After this change, the properties are well set and the events are well-displayed