### PR TITLE
fix: Update to JDK21 - EXO-71474 - Meeds-io/MIPs#91

### DIFF
--- a/agenda-connectors-services/pom.xml
+++ b/agenda-connectors-services/pom.xml
@@ -142,13 +142,5 @@
   </dependencies>
   <build>
     <finalName>agenda-connectors-services</finalName>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>@{argLine} ${env.MAVEN_OPTS} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED </argLine>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Remove usage of SecurityManager as it is deprecated for removal in jdk21 Remove also usage of classes

SecurityHelper
PrivilegedSystemHelper
PrivilegedFileHelper
SecureList
SecureSet
SecureCollections
These classes are here only to use securityManager, and as it is removed, it is no more necessary

Resolves meeds-io/MIPs#91