### PR TITLE
fix: [BUG] Agenda :  can't connect Google calendar accoun - EXO-71912

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
@@ -114,7 +114,6 @@ export default {
       return this.authorize().then(tokenResponse => {
         if (tokenResponse && tokenResponse.access_token) {
           this.canPush = this.cientOauth.hasGrantedAllScopes(tokenResponse, this.SCOPE_WRITE);
-          this.identity.prompt();
           return this.authenticate().then(() => {
             return new Promise((resolve, reject) => {
               if (this.credential) {
@@ -356,6 +355,7 @@ function initGoogleConnector(connector) {
     connector.identity.initialize({
       client_id: connector.CLIENT_ID,
       select_by: 'user',
+      use_fedcm_for_prompt: true,
       callback: (credResponse) => {
         if (credResponse && credResponse.credential) {
           const credential = jwt_decode(credResponse.credential);


### PR DESCRIPTION
Prior to this change, using chrome to connect to google calendar account is not working anymore, this is due to that chrome is now using the dedCM (Federated Credential Management), this fix update the code by force using fcm for the prompt UI: "use_fedcm_for_prompt: true" and remove extra google.accounts.id.prompt() call that prenvent the authentication