### PR TITLE
fix: send location and description to Exchange - EXO-62884

### DIFF
--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
@@ -197,7 +197,6 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
         String webConferenceURL = NotificationUtils.getWebConferenceLink(eventOneXo);
         if(StringUtils.isNotBlank(webConferenceURL)) {
           appointment.setMeetingWorkspaceUrl(webConferenceURL);
-          appointment.setIsOnlineMeeting(true);
         }
         appointment.setRecurrence(getEventRecurrence(event.getId()));
         appointment.save(new FolderId(WellKnownFolderName.Calendar), SendInvitationsMode.SendToAllAndSaveCopy);

--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/exchange-connector/agendaExchangeConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/exchange-connector/agendaExchangeConnector.js
@@ -67,6 +67,9 @@ export default {
     const exchangeEvent = {
       id: event.id,
       summary: event.summary,
+      description: event.description,
+      location: event.location,
+      conferences: event.conferences,
       start: event.start,
       end: event.end,
       remoteProviderName: this.name,


### PR DESCRIPTION
The properties location, description and web conferencing URL were not synchronized with Exchange, the fix will add them to the object sent when synchronizing.