### PR TITLE
fix: synchronize location, description and web conf URL - EXO-62884

### DIFF
--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
@@ -21,9 +21,11 @@ import java.time.ZonedDateTime;
 import java.time.format.TextStyle;
 import java.util.*;
 
+import microsoft.exchange.webservices.data.core.enumeration.property.BodyType;
 import microsoft.exchange.webservices.data.core.enumeration.property.time.DayOfTheWeek;
 import microsoft.exchange.webservices.data.core.enumeration.property.time.Month;
 import microsoft.exchange.webservices.data.core.exception.misc.ArgumentOutOfRangeException;
+import microsoft.exchange.webservices.data.property.complex.MessageBody;
 import microsoft.exchange.webservices.data.property.complex.recurrence.pattern.Recurrence;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.agenda.model.Event;
@@ -33,6 +35,7 @@ import org.exoplatform.agenda.rest.model.EventEntity;
 import org.exoplatform.agenda.service.AgendaEventService;
 import org.exoplatform.agenda.service.AgendaRemoteEventService;
 import org.exoplatform.agenda.util.AgendaDateUtils;
+import org.exoplatform.agenda.util.NotificationUtils;
 import org.exoplatform.agendaconnector.model.ExchangeUserSetting;
 import org.exoplatform.agendaconnector.storage.ExchangeConnectorStorage;
 import org.exoplatform.agendaconnector.utils.ExchangeConnectorUtils;
@@ -59,13 +62,13 @@ import org.exoplatform.services.log.Log;
 
 public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
 
-  private ExchangeConnectorStorage exchangeConnectorStorage;
+  private ExchangeConnectorStorage     exchangeConnectorStorage;
 
-  private AgendaRemoteEventService agendaRemoteEventService;
+  private AgendaRemoteEventService     agendaRemoteEventService;
 
-  private AgendaEventService       agendaEventService;
+  private AgendaEventService           agendaEventService;
 
-  private static final Log LOG = ExoLogger.getLogger(ExchangeConnectorServiceImpl.class);
+  private static final Log             LOG = ExoLogger.getLogger(ExchangeConnectorServiceImpl.class);
 
 
   public ExchangeConnectorServiceImpl(ExchangeConnectorStorage exchangeConnectorStorage,
@@ -179,6 +182,7 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
   @Override
   public void pushEventToExchange(long userIdentityId, EventEntity event, ZoneId userTimeZone) throws IllegalAccessException {
     ExchangeUserSetting exchangeUserSetting = getExchangeSetting(userIdentityId);
+    Event eventOneXo = agendaEventService.getEventById(event.getId());
     try (ExchangeService exchangeService = ExchangeConnectorUtils.connectExchangeServer(exchangeUserSetting)) {
       RemoteEvent remoteEvent = agendaRemoteEventService.findRemoteEvent(event.getId(), userIdentityId);
       if (remoteEvent == null) {
@@ -188,6 +192,12 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
         ZonedDateTime endDate = AgendaDateUtils.parseRFC3339ToZonedDateTime(event.getEnd(), userTimeZone);
         appointment.setStart(AgendaDateUtils.toDate(startDate));
         appointment.setEnd(AgendaDateUtils.toDate(endDate));
+        appointment.setLocation(event.getLocation());
+        appointment.setBody(new MessageBody(BodyType.HTML, event.getDescription()));
+        String webConferenceURL = NotificationUtils.getWebConferenceLink(eventOneXo);
+        if(StringUtils.isNotBlank(webConferenceURL)) {
+          appointment.setMeetingWorkspaceUrl(webConferenceURL);
+        }
         appointment.setRecurrence(getEventRecurrence(event.getId()));
         appointment.save(new FolderId(WellKnownFolderName.Calendar), SendInvitationsMode.SendToAllAndSaveCopy);
         remoteEvent = new RemoteEvent();

--- a/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImplTest.java
+++ b/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImplTest.java
@@ -14,12 +14,12 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.ecs.html.Col;
 import org.exoplatform.agenda.constant.EventRecurrenceFrequency;
 import org.exoplatform.agenda.constant.EventRecurrenceType;
 import org.exoplatform.agenda.model.Event;
 import org.exoplatform.agenda.model.EventRecurrence;
 import org.exoplatform.agenda.service.AgendaEventService;
+import org.exoplatform.agenda.util.NotificationUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +45,7 @@ import microsoft.exchange.webservices.data.search.ItemView;
 import microsoft.exchange.webservices.data.search.filter.SearchFilter;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ ExchangeConnectorUtils.class, ExchangeService.class })
+@PrepareForTest({ ExchangeConnectorUtils.class, ExchangeService.class, NotificationUtils.class })
 public class ExchangeConnectorServiceImplTest {
 
   private ExchangeConnectorServiceImpl exchangeConnectorService;
@@ -68,6 +68,7 @@ public class ExchangeConnectorServiceImplTest {
     exchangeConnectorService = new ExchangeConnectorServiceImpl(exchangeConnectorStorage,
                                                                 agendaRemoteEventService,
                                                                 agendaEventService);
+    PowerMockito.mockStatic(NotificationUtils.class);
   }
   
   @Test
@@ -103,7 +104,7 @@ public class ExchangeConnectorServiceImplTest {
     
     when(agendaRemoteEventService.findRemoteEvent(1, 1)).thenReturn(null);
     when(exchangeService.getRequestedServerVersion()).thenReturn(ExchangeVersion.Exchange2010_SP2);
-    
+
     // When
     EventEntity eventEntity = new EventEntity();
     eventEntity.setId(1);

--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/exchange-connector/agendaExchangeConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/exchange-connector/agendaExchangeConnector.js
@@ -67,6 +67,9 @@ export default {
     const exchangeEvent = {
       id: event.id,
       summary: event.summary,
+      description: event.description,
+      location: event.location,
+      conferences: event.conferences,
       start: event.start,
       end: event.end,
       remoteProviderName: this.name,


### PR DESCRIPTION
The fix will add location, description and web conferencing call URL to the event pushed to MS Exchange.

The properties location, description and web conferencing URL were not synchronized with Exchange, the fix will add them to the object sent when synchronizing.