### PR TITLE
fix: Display exchange recurring events occurrences EXO-84231

### DIFF
--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImpl.java
@@ -41,22 +41,21 @@ import org.exoplatform.agendaconnector.storage.ExchangeConnectorStorage;
 import org.exoplatform.agendaconnector.utils.ExchangeConnectorUtils;
 
 import microsoft.exchange.webservices.data.core.ExchangeService;
+import microsoft.exchange.webservices.data.core.PropertySet;
+import microsoft.exchange.webservices.data.core.enumeration.property.BasePropertySet;
 import microsoft.exchange.webservices.data.core.enumeration.property.WellKnownFolderName;
-import microsoft.exchange.webservices.data.core.enumeration.search.LogicalOperator;
 import microsoft.exchange.webservices.data.core.enumeration.service.ConflictResolutionMode;
 import microsoft.exchange.webservices.data.core.enumeration.service.DeleteMode;
 import microsoft.exchange.webservices.data.core.enumeration.service.SendInvitationsMode;
 import microsoft.exchange.webservices.data.core.enumeration.service.SendInvitationsOrCancellationsMode;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
 import microsoft.exchange.webservices.data.core.service.item.Appointment;
-import microsoft.exchange.webservices.data.core.service.item.Item;
 import microsoft.exchange.webservices.data.core.service.schema.AppointmentSchema;
+import microsoft.exchange.webservices.data.core.service.schema.ItemSchema;
 import microsoft.exchange.webservices.data.property.complex.FolderId;
 import microsoft.exchange.webservices.data.property.complex.ItemId;
-import microsoft.exchange.webservices.data.property.definition.PropertyDefinition;
+import microsoft.exchange.webservices.data.search.CalendarView;
 import microsoft.exchange.webservices.data.search.FindItemsResults;
-import microsoft.exchange.webservices.data.search.ItemView;
-import microsoft.exchange.webservices.data.search.filter.SearchFilter;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -106,66 +105,38 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
                                              ZoneId userTimeZone) throws IllegalAccessException {
     ExchangeUserSetting exchangeUserSetting = getExchangeSetting(userIdentityId);
     try (ExchangeService exchangeService = ExchangeConnectorUtils.connectExchangeServer(exchangeUserSetting)) {
-      ItemView view = new ItemView(100);
+      ZonedDateTime startZonedDateTime = parsePeriodDate(start, userTimeZone);
+      ZonedDateTime endZonedDatetime = parsePeriodDate(end, userTimeZone);
 
-      ZonedDateTime startZonedDateTime = AgendaDateUtils.parseAllDayDateToZonedDateTime(start);
-      SearchFilter exchangeStartSearchFilter =
-                                             new SearchFilter.IsGreaterThanOrEqualTo(AppointmentSchema.Start,
-                                                                                     AgendaDateUtils.toDate(startZonedDateTime));
-      ZonedDateTime endZonedDatetime = AgendaDateUtils.parseAllDayDateToZonedDateTime(end).plusDays(1);// We
-                                                                                                       // have
-                                                                                                       // added
-                                                                                                       // on
-                                                                                                       // day
-                                                                                                       // in
-                                                                                                       // order
-                                                                                                       // to
-                                                                                                       // get
-                                                                                                       // events
-                                                                                                       // of
-                                                                                                       // the
-                                                                                                       // end
-                                                                                                       // date
-                                                                                                       // day
-      SearchFilter exchangeEndSearchFilter = new SearchFilter.IsLessThanOrEqualTo(AppointmentSchema.End,
-                                                                                  AgendaDateUtils.toDate(endZonedDatetime));
-
-      SearchFilter exchangeEventsSearchFilter = new SearchFilter.SearchFilterCollection(LogicalOperator.And,
-                                                                                        exchangeStartSearchFilter,
-                                                                                        exchangeEndSearchFilter);
-      FindItemsResults<Item> exchangeEventsItems = exchangeService.findItems(WellKnownFolderName.Calendar,
-                                                                             exchangeEventsSearchFilter,
-                                                                             view);
+      CalendarView calendarView = new CalendarView(AgendaDateUtils.toDate(startZonedDateTime),
+                                                   AgendaDateUtils.toDate(endZonedDatetime),
+                                                   ExchangeConnectorUtils.EXCHANGE_MAX_EVENTS);
+      calendarView.setPropertySet(new PropertySet(BasePropertySet.IdOnly,
+                                                  ItemSchema.Subject,
+                                                  AppointmentSchema.Start,
+                                                  AppointmentSchema.End,
+                                                  AppointmentSchema.IsAllDayEvent));
+      FindItemsResults<Appointment> exchangeAppointments = exchangeService.findAppointments(WellKnownFolderName.Calendar,
+                                                                                            calendarView);
       List<EventEntity> exchangeEvents = new ArrayList<>();
-      for (Item exchangeEventItem : exchangeEventsItems) {
+      for (Appointment exchangeAppointment : exchangeAppointments) {
         EventEntity exchangeEvent = new EventEntity();
-        exchangeEvent.setRemoteId(String.valueOf(exchangeEventItem.getId()));
-        exchangeEvent.setSummary(exchangeEventItem.getSubject());
-        Map<PropertyDefinition, Object> exchangeEventItemProperties = exchangeEventItem.getPropertyBag().getProperties();
+        exchangeEvent.setRemoteId(String.valueOf(exchangeAppointment.getId()));
+        exchangeEvent.setSummary(exchangeAppointment.getSubject());
+        boolean allDay = Boolean.TRUE.equals(exchangeAppointment.getIsAllDayEvent());
+        exchangeEvent.setAllDay(allDay);
 
-        Date exchangeEventStartDate =
-                                    (Date) Objects.requireNonNull(exchangeEventItemProperties.entrySet()
-                                                                                             .stream()
-                                                                                             .filter(exchangeEventItemProperty -> exchangeEventItemProperty.getKey()
-                                                                                                                                                           .getUri()
-                                                                                                                                                           .equals(ExchangeConnectorUtils.EXCHANGE_APPOINTMENT_SCHEMA_START))
-                                                                                             .findFirst()
-                                                                                             .orElse(null))
-                                                  .getValue();
-        ZonedDateTime exchangeEventStartDateTime = AgendaDateUtils.fromDate(exchangeEventStartDate)
+        ZonedDateTime exchangeEventStartDateTime = AgendaDateUtils.fromDate(exchangeAppointment.getStart())
                                                                   .withZoneSameInstant(userTimeZone);
         exchangeEvent.setStart(AgendaDateUtils.toRFC3339Date(exchangeEventStartDateTime));
 
-        Date exchangeEventEndDate =
-                                  (Date) Objects.requireNonNull(exchangeEventItemProperties.entrySet()
-                                                                                           .stream()
-                                                                                           .filter(exchangeEventItemProperty -> exchangeEventItemProperty.getKey()
-                                                                                                                                                         .getUri()
-                                                                                                                                                         .equals(ExchangeConnectorUtils.EXCHANGE_APPOINTMENT_SCHEMA_END))
-                                                                                           .findFirst()
-                                                                                           .orElse(null))
-                                                .getValue();
-        ZonedDateTime exchangeEventEndDateTime = AgendaDateUtils.fromDate(exchangeEventEndDate).withZoneSameInstant(userTimeZone);
+        ZonedDateTime exchangeEventEndDateTime = AgendaDateUtils.fromDate(exchangeAppointment.getEnd())
+                                                                .withZoneSameInstant(userTimeZone);
+        if (allDay) {
+          // Exchange returns the day following the last day of the event as end
+          // date of an all day event
+          exchangeEventEndDateTime = exchangeEventEndDateTime.minusDays(1);
+        }
         exchangeEvent.setEnd(AgendaDateUtils.toRFC3339Date(exchangeEventEndDateTime));
         exchangeEvents.add(exchangeEvent);
       }
@@ -244,6 +215,19 @@ public class ExchangeConnectorServiceImpl implements ExchangeConnectorService {
       LOG.error("User {} is not allowed to connect to exchange server",userIdentityId,e);
       throw new IllegalAccessException("User '" + userIdentityId + "' is not allowed to connect to exchange server");
     }
+  }
+
+  private ZonedDateTime parsePeriodDate(String date, ZoneId userTimeZone) {
+    if (StringUtils.isBlank(date)) {
+      return null;
+    }
+    // The '+' of the time zone offset is decoded as a space when the date isn't
+    // URL encoded by the caller
+    String rfc3339Date = date.replace(' ', '+');
+    if (rfc3339Date.length() > 10) {
+      return AgendaDateUtils.parseRFC3339ToZonedDateTime(rfc3339Date, userTimeZone);
+    }
+    return AgendaDateUtils.parseAllDayDateToZonedDateTime(rfc3339Date).withZoneSameLocal(userTimeZone);
   }
 
   private Recurrence getEventRecurrence(long eventId) throws ArgumentOutOfRangeException {

--- a/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/utils/ExchangeConnectorUtils.java
+++ b/agenda-connectors-services/src/main/java/org/exoplatform/agendaconnector/utils/ExchangeConnectorUtils.java
@@ -57,11 +57,9 @@ public class ExchangeConnectorUtils {
   public static final String EXCHANGE_SERVER_URL_PROPERTY = "exo.exchange.server.url";
   
   public static final String EWS_URL = "/EWS/Exchange.asmx";
-  
-  public static final String EXCHANGE_APPOINTMENT_SCHEMA_START = "calendar:Start";
-  
-  public static final String EXCHANGE_APPOINTMENT_SCHEMA_END = "calendar:End";
-  
+
+  public static final int    EXCHANGE_MAX_EVENTS = 100;
+
   private ExchangeConnectorUtils() {
   }
 
@@ -114,7 +112,7 @@ public class ExchangeConnectorUtils {
   private static void checkConnection(ExchangeService exchangeService) throws Exception {
     //this function will verify if settings entered by user are functionnal
 
-    ItemView view = new ItemView(100);
+    ItemView view = new ItemView(EXCHANGE_MAX_EVENTS);
 
     ZonedDateTime startZonedDateTime = ZonedDateTime.now();
     SearchFilter exchangeStartSearchFilter =

--- a/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImplTest.java
+++ b/agenda-connectors-services/src/test/java/org/exoplatform/agendaconnector/service/ExchangeConnectorServiceImplTest.java
@@ -1,6 +1,8 @@
 package org.exoplatform.agendaconnector.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -23,6 +25,7 @@ import org.exoplatform.agenda.util.NotificationUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -39,10 +42,9 @@ import microsoft.exchange.webservices.data.core.ExchangeService;
 import microsoft.exchange.webservices.data.core.enumeration.misc.ExchangeVersion;
 import microsoft.exchange.webservices.data.core.enumeration.property.WellKnownFolderName;
 import microsoft.exchange.webservices.data.core.service.item.Appointment;
-import microsoft.exchange.webservices.data.core.service.item.Item;
+import microsoft.exchange.webservices.data.property.complex.ItemId;
+import microsoft.exchange.webservices.data.search.CalendarView;
 import microsoft.exchange.webservices.data.search.FindItemsResults;
-import microsoft.exchange.webservices.data.search.ItemView;
-import microsoft.exchange.webservices.data.search.filter.SearchFilter;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ ExchangeConnectorUtils.class, ExchangeService.class, NotificationUtils.class })
@@ -79,18 +81,100 @@ public class ExchangeConnectorServiceImplTest {
     exchangeUserSetting.setPassword("password");
     when(exchangeConnectorStorage.getExchangeSetting(1)).thenReturn(exchangeUserSetting);
     System.setProperty("exo.exchange.server.url", "server.url");
-    FindItemsResults<Item> exchangeEventsItems = new FindItemsResults<Item>();
-    when(exchangeService.findItems(any(WellKnownFolderName.class), any(SearchFilter.class), any(ItemView.class))).thenReturn(exchangeEventsItems);
-    
-    // When
+
     ZoneId dstTimeZone = ZoneId.of("Europe/Paris");
-    ZonedDateTime startDate =
-            ZonedDateTime.of(LocalDate.now(), LocalTime.of(10, 0), dstTimeZone).withZoneSameInstant(dstTimeZone);
-    ZonedDateTime endDate = startDate.plusHours(1);
-    List<EventEntity> retrievedExchangeEvents = exchangeConnectorService.getExchangeEvents(1, AgendaDateUtils.toRFC3339Date(startDate), AgendaDateUtils.toRFC3339Date(endDate), ZoneId.of("Europe/Paris"));
+    ZonedDateTime periodStart = ZonedDateTime.of(LocalDate.now(), LocalTime.of(0, 0), dstTimeZone);
+    ZonedDateTime periodEnd = ZonedDateTime.of(LocalDate.now(), LocalTime.of(23, 59), dstTimeZone);
+    ZonedDateTime firstOccurrenceStart = periodStart.plusHours(10);
+    ZonedDateTime secondOccurrenceStart = firstOccurrenceStart.plusDays(1);
+
+    FindItemsResults<Appointment> exchangeAppointments = new FindItemsResults<>();
+    // Two occurrences of the same recurring series and one all day event
+    exchangeAppointments.getItems().add(mockAppointment("occurrenceId1",
+                                                        "every day event",
+                                                        firstOccurrenceStart,
+                                                        firstOccurrenceStart.plusHours(1),
+                                                        false));
+    exchangeAppointments.getItems().add(mockAppointment("occurrenceId2",
+                                                        "every day event",
+                                                        secondOccurrenceStart,
+                                                        secondOccurrenceStart.plusHours(1),
+                                                        false));
+    exchangeAppointments.getItems().add(mockAppointment("allDayEventId",
+                                                        "all day event",
+                                                        periodStart,
+                                                        periodStart.plusDays(1),
+                                                        true));
+    when(exchangeService.findAppointments(any(WellKnownFolderName.class),
+                                          any(CalendarView.class))).thenReturn(exchangeAppointments);
+
+    // When
+    List<EventEntity> retrievedExchangeEvents = exchangeConnectorService.getExchangeEvents(1,
+                                                                                           AgendaDateUtils.toRFC3339Date(periodStart),
+                                                                                           AgendaDateUtils.toRFC3339Date(periodEnd),
+                                                                                           dstTimeZone);
 
     // Then
-    assertEquals(exchangeEventsItems.getItems().size(), retrievedExchangeEvents.size());
+    // All the occurrences of a recurring event are retrieved and not only its recurring master
+    assertEquals(exchangeAppointments.getItems().size(), retrievedExchangeEvents.size());
+    assertEquals("occurrenceId1", retrievedExchangeEvents.get(0).getRemoteId());
+    assertEquals("every day event", retrievedExchangeEvents.get(0).getSummary());
+    assertEquals(AgendaDateUtils.toRFC3339Date(firstOccurrenceStart), retrievedExchangeEvents.get(0).getStart());
+    assertFalse(retrievedExchangeEvents.get(0).isAllDay());
+    assertEquals("occurrenceId2", retrievedExchangeEvents.get(1).getRemoteId());
+    assertEquals(AgendaDateUtils.toRFC3339Date(secondOccurrenceStart), retrievedExchangeEvents.get(1).getStart());
+    assertTrue(retrievedExchangeEvents.get(2).isAllDay());
+    // The end date of an all day event is the last day of the event
+    assertEquals(AgendaDateUtils.toRFC3339Date(periodStart), retrievedExchangeEvents.get(2).getEnd());
+
+    // The events are searched over the whole requested period, kept in the user time zone
+    ArgumentCaptor<CalendarView> calendarViewCaptor = ArgumentCaptor.forClass(CalendarView.class);
+    verify(exchangeService).findAppointments(any(WellKnownFolderName.class), calendarViewCaptor.capture());
+    assertEquals(AgendaDateUtils.toDate(periodStart), calendarViewCaptor.getValue().getStartDate());
+    assertEquals(AgendaDateUtils.toDate(periodEnd), calendarViewCaptor.getValue().getEndDate());
+  }
+
+  @Test
+  public void testGetExchangeEventsWithNotUrlEncodedDates() throws Exception {
+    // Given
+    ExchangeUserSetting exchangeUserSetting = new ExchangeUserSetting();
+    exchangeUserSetting.setUsername("username");
+    exchangeUserSetting.setPassword("password");
+    when(exchangeConnectorStorage.getExchangeSetting(1)).thenReturn(exchangeUserSetting);
+    System.setProperty("exo.exchange.server.url", "server.url");
+    when(exchangeService.findAppointments(any(WellKnownFolderName.class),
+                                          any(CalendarView.class))).thenReturn(new FindItemsResults<>());
+
+    ZoneId dstTimeZone = ZoneId.of("Europe/Paris");
+    ZonedDateTime periodStart = ZonedDateTime.of(LocalDate.now(), LocalTime.of(0, 0), dstTimeZone);
+    ZonedDateTime periodEnd = ZonedDateTime.of(LocalDate.now(), LocalTime.of(23, 59), dstTimeZone);
+    // The '+' of the time zone offset is received as a space when the caller
+    // doesn't URL encode the dates
+    String start = AgendaDateUtils.toRFC3339Date(periodStart).replace('+', ' ');
+    String end = AgendaDateUtils.toRFC3339Date(periodEnd).replace('+', ' ');
+
+    // When
+    exchangeConnectorService.getExchangeEvents(1, start, end, dstTimeZone);
+
+    // Then
+    ArgumentCaptor<CalendarView> calendarViewCaptor = ArgumentCaptor.forClass(CalendarView.class);
+    verify(exchangeService).findAppointments(any(WellKnownFolderName.class), calendarViewCaptor.capture());
+    assertEquals(AgendaDateUtils.toDate(periodStart), calendarViewCaptor.getValue().getStartDate());
+    assertEquals(AgendaDateUtils.toDate(periodEnd), calendarViewCaptor.getValue().getEndDate());
+  }
+
+  private Appointment mockAppointment(String itemId,
+                                      String subject,
+                                      ZonedDateTime start,
+                                      ZonedDateTime end,
+                                      boolean allDay) throws Exception {
+    Appointment appointment = mock(Appointment.class);
+    when(appointment.getId()).thenReturn(new ItemId(itemId));
+    when(appointment.getSubject()).thenReturn(subject);
+    when(appointment.getStart()).thenReturn(AgendaDateUtils.toDate(start));
+    when(appointment.getEnd()).thenReturn(AgendaDateUtils.toDate(end));
+    when(appointment.getIsAllDayEvent()).thenReturn(allDay);
+    return appointment;
   }
 
   @Test

--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/js/agendaExchangeService.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/js/agendaExchangeService.js
@@ -60,7 +60,12 @@ export const deleteExchangeSetting = () => {
 };
 
 export const getExchangeEvents = (start, end) => {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/exchange/events?start=${start}&end=${end}&timeZoneId=${USER_TIMEZONE_ID}`, {
+  const params = new URLSearchParams({
+    start,
+    end,
+    timeZoneId: USER_TIMEZONE_ID,
+  });
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/v1/exchange/events?${params.toString()}`, {
     credentials: 'include',
     method: 'GET',
   }).then(resp => {


### PR DESCRIPTION
Exchange events were retrieved with a FindItem request filtered on Start/End, which returns the recurring master of each series instead of its occurrences: a recurring event was displayed only on the date of its first occurrence, and not at all when the series had started before the displayed period.

The appointments are now retrieved through a CalendarView, which expands the occurrences over the requested period, the same way the Google connector requests single events. All day events are flagged as such, and the period dates are URL encoded by the caller then parsed in the user time zone, instead of being reduced to their date part.