### PR TITLE
fix: forget the write grant when the account is disconnected EXO-89449

### DIFF
--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/google-connector/agendaGoogleConnector.js
@@ -138,6 +138,22 @@ export default {
       });
     }
   },
+  /**
+   * Forgets that write access was granted.
+   * <p>
+   * canPush is not a property of this connector but of the account attached to
+   * it: it records that the user granted the write scope, and it is recomputed
+   * from hasGrantedAllScopes() every time a token is obtained. Disconnecting
+   * revokes that grant, so keeping the flag would claim a permission that no
+   * longer exists — connect() reads it to decide whether to ask for write
+   * access, and would skip asking, leaving the client without a usable token
+   * until the first copy failed.
+   *
+   * @returns {void}
+   */
+  resetPushAbility() {
+    this.canPush = false;
+  },
   disconnect() {
     this.loadingCallback(this, true);
     return removeToken().then(() => {

--- a/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
+++ b/agenda-connectors-webapp/src/main/webapp/vue-app/agenda-connectors/office-connector/agendaOfficeConnector.js
@@ -100,6 +100,16 @@ export default {
       })
       .finally(() => this.loadingCallback(this, false));
   },
+  /**
+   * Forgets that write access was granted, for the same reason as the Google
+   * connector: canPush here records a consented scope, not a static ability,
+   * and disconnecting is what takes the consent away.
+   *
+   * @returns {void}
+   */
+  resetPushAbility() {
+    this.canPush = false;
+  },
   disconnect() {
     return new Promise((resolve) => {
       this.officeApi.browserStorage.removeAllAccounts();


### PR DESCRIPTION
**Pairs with [exoplatform/agenda#1034](https://github.com/exoplatform/agenda/pull/1034) — both are needed.** That PR adds the hook; this one implements it. Merging this alone is harmless but inert; merging that one alone changes nothing.

`canPush` on the Google and Office connectors is not a property of the connector but of the **account attached to it**. Both start at `false` and recompute it from `hasGrantedAllScopes(…, SCOPE_WRITE)` every time a token is obtained:

```js
canPush: false,                                                        // agendaGoogleConnector.js:29
this.canPush = this.cientOauth.hasGrantedAllScopes(…, this.SCOPE_WRITE);  // :67, :75, :116, :165, :338
```

Disconnecting revokes the token and deletes it server-side, so the grant the flag records is gone. It nonetheless survived on the shared connector object after EXO-89404 stopped clearing it centrally — and `connect()` reads exactly that flag to decide whether to ask for write access again:

```js
if (askWriteAccess && !this.canPush) {   // :113 — skipped while the flag is stale
```

So reconnecting skipped the request and left the client without a usable token, until the first copy failed on a 401 and tried to reopen consent from inside a promise chain.

## The change

Both connectors implement `resetPushAbility()`, the hook agenda calls when it resets a connector, setting the flag back to `false` so the next connect asks for the scope again. Connectors whose ability really is static — CalDAV's `canPush: true` — implement nothing and keep the behaviour EXO-89404 restored for them.

## Testing

⚠️ **Not verified at runtime.** Traced in code; the webapp builds and lints. The Google connector needs an OAuth client id, absent on a local platform, so this needs acceptance:

1. Connect Google with "copy the meetings you organise" on
2. Disconnect
3. Reconnect **without reloading the page**
4. Create an event you organise, watch DevTools → Network

**Before:** no consent prompt, `events.insert` 401s, popup blocked or late. **After:** write access is requested again and the copy succeeds.

Office is changed identically. Its full connect/disconnect lifecycle was **not** traced end to end — the flag is mutated the same way (`agendaOfficeConnector.js:89,205,213`), so it is exposed to the same defect, but that inference deserves the same manual check.

## Review level

**N2** — cross-connector seam, no ACL/schema/trust boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)